### PR TITLE
Refactor: extract tab logic into controllers, add AppState, logging and file dialogs

### DIFF
--- a/calculations/common.py
+++ b/calculations/common.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/dq.py
+++ b/calculations/dq.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/dqmq.py
+++ b/calculations/dqmq.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/fft.py
+++ b/calculations/fft.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/fitting.py
+++ b/calculations/fitting.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/gs.py
+++ b/calculations/gs.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/io.py
+++ b/calculations/io.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/preprocessing.py
+++ b/calculations/preprocessing.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/se.py
+++ b/calculations/se.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/calculations/t1t2.py
+++ b/calculations/t1t2.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -4,4 +4,5 @@ from .dq_temp_controller import DQTempTabController
 from .t1t2_controller import T1T2TabController
 from .dqmq_controller import DQMQTabController
 from .gs_controller import GSTabController
-from .extra_controller import ExtraTabController
+
+from .general_se_dq_controller import GeneralSEDQController

--- a/controllers/base_tab_controller.py
+++ b/controllers/base_tab_controller.py
@@ -1,1 +1,17 @@
-"""Module scaffold for refactor."""
+class BaseTabController:
+    def __init__(self, ui, state, parent=None):
+        self.ui = ui
+        self.state = state
+        self.parent = parent
+
+    def read_column_values(self, table, column):
+        values = []
+        for row in range(table.rowCount()):
+            item = table.item(row, column)
+            if item is None:
+                continue
+            try:
+                values.append(float(item.text()))
+            except ValueError:
+                continue
+        return values

--- a/controllers/dq_controller.py
+++ b/controllers/dq_controller.py
@@ -1,11 +1,141 @@
-class DQTabController:
-    def __init__(self, main_window):
-        self.main_window = main_window
+import numpy as np
+from PySide6.QtWidgets import QTableWidgetItem
+from scipy.optimize import curve_fit
+
+import Calculator as Cal
+from controllers.base_tab_controller import BaseTabController
+
+
+class DQTabController(BaseTabController):
+    def process_processed_file(self, i, filename, x, y, z, m2, t2, file_path):
+        import re
+        match = re.search(r'_(\d+\.\d+)_', filename)
+        dq_time = match.group(1) if match else '0'
+        amplitude = Cal._calculate_amplitude(y, z)
+        dq = Cal.calculate_DQ_intensity(x, amplitude)
+        self.ui.table_DQ.setRowCount(i)
+        self.parent.fill_table(self.ui.table_DQ, dq_time, dq, m2, t2, i)
+        if self.ui.radioButton.isChecked():
+            self.parent.save_figures(file_path, dq_time)
+        self.update_graphs()
 
     def update_graphs(self):
-        if len(self.main_window.selected_files_DQ_single) > 1:
-            self.main_window.linearization()
-            self.main_window.plot_fit()
+        files = getattr(getattr(self.state, "dq", None), "files", None)
+        if files is None:
+            files = getattr(self.state, "dq_files", [])
+        if len(files) > 1:
+            self.linearization()
+            self.plot_fit()
+        else:
+            self.dq_t2_graph()
 
-    def plot_t2_graph(self):
-        self.main_window.dq_t2_graph()
+    def dq_t2_graph(self):
+        x = self.read_column_values(self.ui.table_DQ, 0)
+        y = self.read_column_values(self.ui.table_DQ, 3)
+        self.ui.DQ_Widget_1.clear()
+        self.ui.DQ_Widget_1.plot(
+            x, y, pen=None, symbol='o', symbolPen=None, symbolBrush=(255, 0, 0, 255), symbolSize=10
+        )
+
+    def linearization(self):
+        time_min = self.ui.dq_min.value()
+        time_max = self.ui.dq_max.value()
+        dq_time = np.array(self.read_column_values(self.ui.table_DQ, 0))
+        t2 = np.array(self.read_column_values(self.ui.table_DQ, 3))
+        dq = np.array(self.read_column_values(self.ui.table_DQ, 1))
+
+        x = dq_time[(dq_time >= time_min) & (dq_time <= time_max)]
+        if len(x) < 3:
+            time_min = 0
+            time_max = 20
+            self.ui.dq_min.setValue(time_min)
+            self.ui.dq_max.setValue(time_max)
+            x = dq_time[(dq_time >= time_min) & (dq_time <= time_max)]
+
+        y = t2[(dq_time >= time_min) & (dq_time <= time_max)]
+        if len(x) <= 1 or len(y) <= 1:
+            return
+
+        coeff = np.polyfit(x, y, 1)
+        integral = np.trapz(dq)
+        dq_norm = dq / integral
+
+        self.ui.table_DQ.setColumnCount(5)
+        self.ui.table_DQ.setColumnWidth(4, 70)
+        self.ui.table_DQ.setHorizontalHeaderItem(4, QTableWidgetItem("T₂* lin"))
+        self.ui.table_DQ.setColumnCount(6)
+        self.ui.table_DQ.setColumnWidth(5, 70)
+        self.ui.table_DQ.setHorizontalHeaderItem(5, QTableWidgetItem("DQ Norm"))
+
+        for row in range(self.ui.table_DQ.rowCount()):
+            t2_lin = round(coeff[0] * dq_time[row] + coeff[1], 4)
+            self.ui.table_DQ.setItem(row, 4, QTableWidgetItem(str(t2_lin)))
+            self.ui.table_DQ.setItem(row, 5, QTableWidgetItem(str(round(dq_norm[row], 4))))
+
+        x_line = np.arange(0, 105.1, 0.1)
+        y_line = np.polyval(coeff, x_line)
+        self.dq_t2_graph()
+        self.ui.DQ_Widget_1.plot(x_line, y_line, pen='r')
+        self.t2_dq_graph()
+
+    def t2_dq_graph(self):
+        x = self.read_column_values(self.ui.table_DQ, 4)
+        y = self.read_column_values(self.ui.table_DQ, 5)
+
+        if self.ui.radioButton_Log.isChecked():
+            new_x = np.log10(x)
+            self.ui.DQ_Widget_2.getAxis('bottom').setLabel("log(T₂*)")
+        else:
+            new_x = x
+            self.ui.DQ_Widget_2.getAxis('bottom').setLabel("T₂*")
+
+        self.ui.DQ_Widget_2.clear()
+        self.ui.DQ_Widget_2.plot(
+            new_x, y, pen=None, symbol='o', symbolPen=None, symbolBrush=(255, 0, 0, 255), symbolSize=10
+        )
+
+    def plot_fit(self):
+        _x = self.read_column_values(self.ui.table_DQ, 4)
+        y = self.read_column_values(self.ui.table_DQ, 5)
+
+        button = self.ui.radioButton_Log
+        if button.isChecked():
+            x = np.log10(_x)
+            p = [1, 1, 1, 0]
+            b = ([0, 0, 0, 0, 0], [np.inf, np.inf, np.inf, 1, np.inf])
+            self.ui.DQ_Widget_2.getAxis('bottom').setLabel("log(T₂*)")
+        else:
+            x = _x
+            p = [1, 10, 10, 0]
+            b = ([0, 0, 0, 0, 0], [np.inf, np.inf, np.inf, 1, np.inf])
+            self.ui.DQ_Widget_2.getAxis('bottom').setLabel("T₂*")
+
+        text = self.ui.comboBox_FunctionDQ.currentText()
+        try:
+            x_fit = np.arange(0, np.max(x) + 0.001, 0.01)
+        except Exception:
+            x_fit = np.arange(0, 100 + 0.001, 0.01)
+
+        b1 = ([0, 0, 0, -10], [np.inf, np.inf, np.inf, np.inf])
+        if text == 'Gauss':
+            params, _ = curve_fit(Cal.gaussian, x, y, p0=p, bounds=b1)
+            y_fit, y_r2, cen, fwhm, w = Cal.gaussian(x_fit, *params), Cal.gaussian(x, *params), params[1], params[2], 0
+            button.setEnabled(True)
+        elif text == 'Lorenz':
+            params, _ = curve_fit(Cal.lorenz, x, y, p0=p, bounds=b1)
+            y_fit, y_r2, cen, fwhm, w = Cal.lorenz(x_fit, *params), Cal.lorenz(x, *params), params[1], params[2], 1
+            button.setEnabled(True)
+        elif text == 'Pseudo Voigt':
+            params, _ = curve_fit(Cal.voigt, x, y, bounds=b)
+            y_fit, y_r2, cen, fwhm, w = Cal.voigt(x_fit, *params), Cal.voigt(x, *params), params[1], params[2], params[3]
+            button.setEnabled(True)
+        else:
+            button.setEnabled(False)
+            return
+
+        r_squared = Cal.calculate_r_squared(y, y_r2)
+        self.t2_dq_graph()
+        self.ui.DQ_Widget_2.plot(x_fit, y_fit, pen='r')
+        self.ui.textEdit_4.setText(
+            f"R\u00B2: {round(r_squared, 4)} \nX\u2080: {round(cen, 4)} \nFWHM: {round(fwhm, 4)} \nFraction (Lorenz): {round(w,2)}"
+        )

--- a/controllers/dq_temp_controller.py
+++ b/controllers/dq_temp_controller.py
@@ -1,6 +1,96 @@
-class DQTempTabController:
-    def __init__(self, main_window):
-        self.main_window = main_window
+import os
+import re
 
-    def plot(self):
-        self.main_window.plot_Arr()
+import numpy as np
+import pyqtgraph as pg
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox, QTableWidgetItem
+from scipy.optimize import curve_fit
+
+import Calculator as Cal
+from controllers.base_tab_controller import BaseTabController
+
+
+class DQTempTabController(BaseTabController):
+    def update_DQ_comparison(self):
+        table = self.ui.table_DQ_2
+        table.setRowCount(len(self.parent.selected_DQfiles))
+        for row, parent_folder in enumerate(self.parent.selected_DQfiles, start=0):
+            foldername = os.path.dirname(parent_folder)
+            filename = os.path.basename(parent_folder)
+            try:
+                data = np.loadtxt(parent_folder, delimiter=',')
+                if data.shape[1] < 3:
+                    QMessageBox.warning(self.parent, "Invalid Data", f"The file {foldername} does not have at least 3 columns and will be removed from the table and file list.", QMessageBox.Ok)
+                    table.removeRow(row)
+                    del self.parent.selected_DQfiles[row]
+            except Exception as e:
+                QMessageBox.warning(self.parent, "Invalid Data", f"The file {foldername} {e} Removed from the table and file list.", QMessageBox.Ok)
+                table.removeRow(row)
+                del self.parent.selected_DQfiles[row]
+            item = QTableWidgetItem(filename)
+            item_name = QTableWidgetItem()
+            pattern = r'Table_DQ_(-?[0-9]+).*.csv'
+            try:
+                item_xaxis = float(re.search(pattern, filename).group(1))
+                item_name.setData(Qt.EditRole, item_xaxis)
+            except Exception:
+                item_name.setData(Qt.EditRole, float(row + 1))
+            table.setItem(row, 0, item)
+            table.setItem(row, 1, item_name)
+        table.resizeColumnsToContents()
+        self.launch()
+
+    def launch(self):
+        try:
+            self.parent.dq_t2 = {}
+            for row, parent_folder in enumerate(self.parent.selected_DQfiles, start=0):
+                data = np.loadtxt(parent_folder, delimiter=',')
+                self.parent.dq_t2[row] = data[:, [4, 5]]
+            self.update_DQ_comparison_plot()
+        except Exception as e:
+            QMessageBox.warning(self.parent, "Corrupted file", f"Couldn't analyse the {os.path.dirname(parent_folder)} because {e}", QMessageBox.Ok)
+
+    def update_DQ_comparison_plot(self):
+        cmap = pg.ColorMap([0, len(self.parent.dq_t2)], [pg.mkColor('b'), pg.mkColor('r')])
+        self.parent.dq_comparison_distribution = {'File name': [], 'X axis': [], 'Center': [], 'FWHM': [], 'Lorentz ratio': [], 'Fitting type': [], 'T2 limit': []}
+        legend = self.ui.DQ_Widget_4.addLegend(offset=(0, 0))
+        legend_fc = self.ui.DQ_Widget_5.addLegend()
+        self.ui.DQ_Widget_5.clear(); self.ui.DQ_Widget_4.clear(); self.ui.DQ_Widget_polyFit.clear()
+        if legend is not None: legend.clear(); legend.setPen((0, 0, 0))
+        if legend_fc is not None: legend_fc.clear(); legend_fc.setPen((0, 0, 0))
+        legend.anchor(itemPos=(1, 0), parentPos=(1, 0))
+        center_g, center_l, center_v, center_d, comparison_par = [], [], [], [], []
+        for row, (key, data) in zip(range(self.ui.table_DQ_2.rowCount()), self.parent.dq_t2.items()):
+            file_name_item = self.ui.table_DQ_2.item(row, 1)
+            file_item = self.ui.table_DQ_2.item(row, 0)
+            if file_name_item is not None:
+                file_name = file_name_item.text()
+                if file_name != 'hide':
+                    try: _cp = float(file_name)
+                    except Exception:
+                        _cp = 0; self.ui.table_DQ_2.setItem(row, 1, QTableWidgetItem('0'))
+                    comparison_par.append(_cp)
+                else:
+                    continue
+            t2_lin, dq_norm = data[:, 0], data[:, 1]
+            p = [1, 5, 5, 0]; b = ([0, 0, 0, 0, 0], [np.inf, np.inf, np.inf, 1, np.inf]); b1 = ([0, 0, 0, -10], [np.inf, np.inf, np.inf, np.inf])
+            t2_fit = np.arange(0, np.max(t2_lin) + 0.001, 0.01)
+            params, _ = curve_fit(Cal.gaussian, t2_lin, dq_norm, p0=p, bounds=b1); cen_g, fwhm_g = params[1], params[2]; center_g.append(cen_g)
+            params, _ = curve_fit(Cal.lorenz, t2_lin, dq_norm, p0=p, bounds=b1); cen_l, fwhm_l = params[1], params[2]; center_l.append(cen_l)
+            params, _ = curve_fit(Cal.voigt, t2_lin, dq_norm, bounds=b); cen_v, fwhm_v = params[1], params[2]; center_v.append(cen_v)
+            y_fit = Cal.voigt(t2_fit, *params)
+            t2d, ndqd, center_derivative = Cal.derivative_peak_find(t2_lin, dq_norm); center_d.append(center_derivative)
+            color = tuple(cmap.map(key))
+            self.ui.DQ_Widget_4.plot(t2_lin, dq_norm, pen=None, symbolPen=None, symbol='o', symbolBrush=color, symbolSize=10, name=file_name)
+            self.ui.DQ_Widget_4.plot(t2_fit, y_fit, pen=color)
+            self.ui.DQ_Widget_polyFit.plot(t2_lin, dq_norm, pen=None, symbolPen=None, symbol='o', symbolBrush=color, symbolSize=10)
+            self.ui.DQ_Widget_polyFit.plot(t2d, ndqd, pen=color)
+            def set_num(r,c,v):
+                it=QTableWidgetItem(); it.setData(Qt.EditRole, round(float(v),2)); self.ui.table_DQ_2.setItem(r,c,it)
+            set_num(row,2,cen_g); set_num(row,3,cen_l); set_num(row,4,cen_v); set_num(row,5,center_derivative)
+            set_num(row,6,fwhm_g); set_num(row,7,fwhm_l); set_num(row,8,fwhm_v)
+        self.ui.DQ_Widget_5.plot(comparison_par, center_g, pen='r', symbolPen=None, symbol='o', symbolBrush='r', name='Gaus')
+        self.ui.DQ_Widget_5.plot(comparison_par, center_l, pen='b', symbolPen=None, symbol='o', symbolBrush='b', name='Lorenz')
+        self.ui.DQ_Widget_5.plot(comparison_par, center_v, pen='k', symbolPen=None, symbol='o', symbolBrush='k', name='Voigt')
+        self.ui.DQ_Widget_5.plot(comparison_par, center_d, pen='g', symbolPen=None, symbol='o', symbolBrush='g', name='Derivative')

--- a/controllers/dqmq_controller.py
+++ b/controllers/dqmq_controller.py
@@ -1,15 +1,155 @@
-class DQMQTabController:
-    def __init__(self, main_window):
-        self.main_window = main_window
+import numpy as np
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox, QTableWidgetItem
+from pyqtgraph import InfiniteLine, mkPen
+
+import Calculator as Cal
+from controllers.base_tab_controller import BaseTabController
+
+
+class DQMQTabController(BaseTabController):
+    def _get_current_file(self):
+        files = self.state.dqmq_files or []
+        if not files:
+            return None
+        return files[0]
+
+    def dq_mq_analysis(self):
+        table = self.ui.table_DQMQ
+        table.clear()
+        try:
+            time, dq, ref = self.plot_original()
+        except Exception as e:
+            QMessageBox.warning(self.parent, "Corrupt File", f"Couldn't read the file beacuse {e}", QMessageBox.Ok)
+            if self.parent is not None:
+                self.parent.clear_list()
+            return
+
+        table.setRowCount(len(time))
+        for row in range(len(time)):
+            table.setItem(row, 0, QTableWidgetItem(str(time[row])))
+            table.setItem(row, 1, QTableWidgetItem(str(dq[row])))
+            table.setItem(row, 2, QTableWidgetItem(str(ref[row])))
+
+        table.resizeColumnsToContents()
+        table.setHorizontalHeaderLabels(['Time', 'DQ', 'Ref', 'nDQ'])
+        self.ui.pushButton_DQMQ_1.setEnabled(True)
+        self.ui.pushButton_DQMQ_2.setEnabled(False)
+        self.ui.pushButton_DQMQ_3.setEnabled(False)
+        self.ui.pushButton_DQMQ_4.setEnabled(True)
 
     def plot_original(self):
-        self.main_window.plot_original()
+        file_path = self._get_current_file()
+        if file_path is None:
+            return np.array([]), np.array([]), np.array([])
+        figure = self.ui.DQMQ_Widget
+        figure.clear()
+        legend = figure.addLegend()
+        legend.clear()
+        figure.addLegend()
+        try:
+            time, dq, ref = Cal.read_data(file_path, 1)
+        except Exception:
+            time, dq, ref = Cal.read_data(file_path, 0)
+
+        time = time + int(self.ui.DQMQtime_shift.value())
+        figure.plot(time, dq, pen=mkPen('r', width=3), name='DQ')
+        figure.plot(time, ref, pen=mkPen('b', width=3), name='Ref')
+        return time, dq, ref
 
     def plot_norm(self):
-        self.main_window.plot_norm()
+        file_path = self._get_current_file()
+        if file_path is None:
+            return
+        figure = self.ui.DQMQ_Widget
+        figure.clear()
+        legend = figure.addLegend()
+        legend.clear()
+        figure.addLegend()
+        noise_level = self.ui.noise.value()
+        time_shift = int(self.ui.DQMQtime_shift.value())
+        time, dq_norm, ref_norm, _, _, _, _, _, _, _ = Cal.dqmq(file_path, 40, 100, 1, noise_level, time_shift)
+        figure.plot(time, dq_norm, pen=mkPen('r', width=3), name='DQ')
+        figure.plot(time, ref_norm, pen=mkPen('b', width=3), name='Ref')
+        self.ui.pushButton_DQMQ_2.setEnabled(True)
+        self.ui.pushButton_DQMQ_3.setEnabled(True)
+        self.ui.dq_min_3.setEnabled(True)
+        self.ui.dq_max_3.setEnabled(True)
+        self.ui.power.setEnabled(True)
 
     def plot_diff(self):
-        self.main_window.plot_diff()
+        file_path = self._get_current_file()
+        if file_path is None:
+            return
+        fit_from = self.ui.dq_min_3.value()
+        fit_to = self.ui.dq_max_3.value()
+        p = self.ui.power.value()
+        noise_level = self.ui.noise.value()
+        time_shift = int(self.ui.DQMQtime_shift.value())
+        figure = self.ui.DQMQ_Widget
+        figure.clear()
+        legend = figure.addLegend()
+        legend.clear()
+        figure.addLegend()
+        time, _, _, diff, dq_norm, ref_norm, _, _, fitted_curve, _ = Cal.dqmq(
+            file_path, fit_from, fit_to, p, noise_level, time_shift
+        )
+        figure.plot(time, dq_norm, pen=mkPen('r', width=2), name='DQ')
+        figure.plot(time, ref_norm, pen=mkPen('b', width=2), name='Ref')
+        figure.plot(time, diff, pen=mkPen('k', width=3), name='Diff')
+        figure.plot(time, fitted_curve, pen=mkPen('m', width=3), name='fitting')
+        self.ui.pushButton_DQMQ_2.setEnabled(True)
+        self.ui.pushButton_DQMQ_3.setEnabled(True)
 
     def plot_nDQ(self):
-        self.main_window.plot_nDQ()
+        file_path = self._get_current_file()
+        if file_path is None:
+            return
+        fit_from = self.ui.dq_min_3.value()
+        fit_to = self.ui.dq_max_3.value()
+        p = self.ui.power.value()
+        noise_level = self.ui.noise.value()
+        time_shift = int(self.ui.DQMQtime_shift.value())
+        smoothing = [self.ui.DQMQSmooth_from.value(), self.ui.DQMQSmooth_to.value(), int(self.ui.DQMQSmooth_window.value())]
+        figure = self.ui.DQMQ_Widget
+        figure.clear()
+        legend = figure.addLegend()
+        legend.clear()
+        figure.addLegend()
+        time, _, _, _, dq_normal, ref_normal, time0, n_dq, _, mq_normal = Cal.dqmq(
+            file_path, fit_from, fit_to, p, noise_level, time_shift, smoothing
+        )
+        figure.addItem(InfiniteLine(pos=0.5, angle=0, pen=mkPen(color=(200, 200, 255), width=2, style=Qt.DashLine)))
+        figure.plot(time, dq_normal, pen=mkPen('r', width=3), name='DQ')
+        figure.plot(time, ref_normal, pen=mkPen('b', width=3), name='Ref')
+        figure.plot(time, mq_normal, pen=mkPen('m', width=3), name='MQ')
+        figure.plot(time0, n_dq, pen=mkPen('k', width=3), symbol='o', symbolPen='k', symbolSize=10, name='nDQ')
+        for row in range(len(time)):
+            self.ui.table_DQMQ.setItem(row, 3, QTableWidgetItem(str(round(n_dq[row + 1], 4))))
+        self.ui.table_DQMQ.resizeColumnsToContents()
+
+    def plot_nDQ_on_Load(self):
+        table = self.ui.table_DQMQ
+        table.resizeColumnsToContents()
+        time, dq_normal, ref_normal, n_dq = [], [], [], []
+        for row in range(table.rowCount()):
+            time.append(float(table.item(row, 0).text()))
+            dq_normal.append(float(table.item(row, 1).text()))
+            ref_normal.append(float(table.item(row, 2).text()))
+            n_dq.append(float(table.item(row, 3).text()))
+
+        time = np.array(time)
+        dq_normal = np.array(dq_normal)
+        ref_normal = np.array(ref_normal)
+        dq_normal, ref_normal, _ = Cal.normalize_mq(dq_normal, ref_normal, 'plus')
+        n_dq = np.insert(np.array(n_dq), 0, 0)
+        time0 = np.insert(time, 0, 0)
+
+        figure = self.ui.DQMQ_Widget
+        figure.clear()
+        legend = figure.addLegend()
+        legend.clear()
+        figure.addLegend()
+        figure.plot(time, dq_normal, pen=mkPen('r', width=3), name='DQ')
+        figure.plot(time, ref_normal, pen=mkPen('b', width=3), name='Ref')
+        figure.plot(time0, n_dq, pen=mkPen('k', width=3), symbol='o', symbolPen='k', symbolSize=10, name='nDQ')

--- a/controllers/extra_controller.py
+++ b/controllers/extra_controller.py
@@ -1,6 +1,0 @@
-class ExtraTabController:
-    def __init__(self, main_window):
-        self.main_window = main_window
-
-    def hide_activation_energy(self):
-        self.main_window.hide_Eact()

--- a/controllers/general_se_dq_controller.py
+++ b/controllers/general_se_dq_controller.py
@@ -1,0 +1,106 @@
+import os
+import numpy as np
+from PySide6.QtWidgets import QMessageBox, QTableWidgetItem
+from scipy.signal import savgol_filter
+import Calculator as Cal
+from controllers.base_tab_controller import BaseTabController
+from dialogs.open_files_dialog import OpenFilesDialog
+import dialogs.phasing_manual as phasing_manual_module
+from dialogs.phasing_manual import PhasingManual
+
+
+class GeneralSEDQController(BaseTabController):
+    def __init__(self, ui, state, parent=None, se_controller=None, dq_controller=None):
+        super().__init__(ui, state, parent)
+        self.se_controller = se_controller
+        self.dq_controller = dq_controller
+
+    def analysis(self):
+        mw=self.parent
+        while self.ui.comboBox_4.count()>0: self.ui.comboBox_4.removeItem(0)
+        if mw.tab=='SE': files=mw.selected_files; self.ui.SEWidget.clear(); self.ui.comboBox_SE_chooseY.setCurrentIndex(-1)
+        else: files=mw.selected_files_DQ_single; self.ui.DQ_Widget_1.clear(); self.ui.DQ_Widget_2.clear(); self.ui.DQ_Widget_4.clear(); self.ui.textEdit_4.setText(''); self.ui.comboBox_FunctionDQ.setCurrentIndex(-1)
+        if len(files)==0: return
+        if self.ui.checkBox_glycerol.isChecked() and mw.selected_files_gly==[]:
+            self.open_select_dialog_glycerol()
+        if self.ui.checkBox_baseline.isChecked() and mw.selected_files_empty==[]:
+            self.open_select_dialog_baseline()
+        mw.disable_buttons(); self.ui.btn_SelectFiles.setEnabled(False); self.ui.btn_Load.setEnabled(False); self.ui.radioButton.setEnabled(False); self.ui.comboBox_4.setCurrentIndex(-1)
+        mw.window_array = np.linspace(self.ui.SmoothWindowFrom.value(), self.ui.SmoothWindowTo.value(), len(files), dtype=np.int32) if self.ui.checkBox_Smooth.isChecked() else np.array([])
+        for i,file_path in enumerate(files,start=1):
+            try:
+                f_g = mw.selected_files_gly[i-1] if self.ui.checkBox_glycerol.isChecked() else []
+                f_e = mw.selected_files_empty[i-1] if self.ui.checkBox_baseline.isChecked() else []
+                self.process_file_data(file_path,f_g,f_e,i)
+            except Exception:
+                self.analysis_error(file_path, files)
+        self.update_legends_and_dq_graphs(); self.ui.btn_Start.setStyleSheet('background-color: none')
+
+    def analysis_error(self, file_path, files):
+        mw=self.parent
+        QMessageBox.warning(mw, "Invalid Data", f"Couldn't read the {os.path.basename(file_path)}. Deleting the file.", QMessageBox.Ok)
+        files.remove(file_path); self.ui.btn_SelectFiles.setEnabled(True); self.ui.btn_Start.setStyleSheet("background-color: none")
+        self.ui.FidWidget.clear(); self.ui.FFTWidget.clear(); self.ui.btn_Phasing.setEnabled(False); mw.enable_buttons()
+
+    def update_legends_and_dq_graphs(self):
+        self.parent.enable_buttons()
+        if self.parent.tab=='DQ': self.dq_controller.update_graphs()
+
+    def process_file_data(self,file_path,file_path_gly,file_path_empty,i):
+        mw=self.parent; filename=os.path.basename(file_path)
+        subtract=self.ui.checkBox_baseline.isChecked()
+        data=np.loadtxt(file_path); x,y,z=data[:,0],data[:,1],data[:,2]
+        Time,Re,Im=Cal.analysis_time_domain(file_path,file_path_empty,subtract)
+        if self.ui.checkBox_glycerol.isChecked():
+            Time_r,Re_r,Im_r=Cal.analysis_time_domain(file_path_gly,[],False); Time,Re,Im=Cal.magnet_inhomogenity_correction(Time,Time_r,Re,Re_r,Im,Im_r)
+        if self.ui.checkBox_long_component.isChecked(): Time,Re,Im=Cal.subtract_long_component(Time,Re,Im)
+        Amp=Cal._calculate_amplitude(Re,Im); mw.update_graphs(Time,Amp,Re,Im,self.ui.FidWidget)
+        Time_fid,Fid=Cal.final_analysis_time_domain(Time,Re,Im,2**16); frequency=Cal._calculate_frequency_scale(Time_fid)
+        FFT=np.fft.fftshift(np.fft.fft(Fid))
+        if mw.window_array.size!=0:
+            window=mw.window_array[i-1]; FFT=np.array(savgol_filter(np.real(FFT),window,1)+1j*savgol_filter(np.imag(FFT),window,1))
+        amp_spectra,re_spectra,im_spectra=Cal._simple_baseline_correction(FFT); Real_apod=Cal._calculate_apodization(re_spectra,frequency)
+        self.state.spectrum.frequency = frequency
+        self.state.spectrum.re_spectra = re_spectra
+        self.state.spectrum.im_spectra = im_spectra
+        mw.update_graphs(frequency,amp_spectra,re_spectra,im_spectra,self.ui.FFTWidget)
+        if self.ui.comboBox_4.findText(filename)==-1: self.ui.comboBox_4.addItem(filename)
+        if self.ui.comboBox_4.currentIndex()==-1:
+            M2,T2=Cal._calculate_M2(Real_apod,frequency)
+            if mw.tab=='SE':
+                self.se_controller.process_processed_file(i, filename, Amp, M2, T2, file_path)
+            elif mw.tab=='DQ':
+                self.dq_controller.process_processed_file(i, filename, x, y, z, M2, T2, file_path)
+
+    def after_phasing(self):
+        mw=self.parent
+        i=self.ui.comboBox_4.currentIndex()
+        frequency = self.state.spectrum.frequency
+        re_spectra = self.state.spectrum.re_spectra
+        im_spectra = self.state.spectrum.im_spectra
+        Real_apod=Cal._calculate_apodization(re_spectra,frequency); Amp_spectra=Cal._calculate_amplitude(re_spectra,im_spectra)
+        mw.update_graphs(frequency,Amp_spectra,re_spectra,im_spectra,self.ui.FFTWidget); M2,T2=Cal._calculate_M2(Real_apod,frequency)
+        table=self.ui.table_SE if mw.tab=='SE' else self.ui.table_DQ
+        table.setItem(i,2,QTableWidgetItem(str(round(M2,6)))); table.setItem(i,3,QTableWidgetItem(str(round(T2,6))))
+        if mw.tab=='SE': self.se_controller.update_graphs()
+        elif mw.tab=='DQ': self.dq_controller.update_graphs()
+
+    def open_phasing_manual(self):
+        mw=self.parent
+        phasing_manual_module.Frequency = self.state.spectrum.frequency
+        phasing_manual_module.Re_spectra = self.state.spectrum.re_spectra
+        phasing_manual_module.Im_spectra = self.state.spectrum.im_spectra
+        mw.phasing_manual_window=PhasingManual()
+        mw.phasing_manual_window.read_data()
+        mw.phasing_manual_window.show()
+        mw.phasing_manual_window.closed.connect(self.after_phasing)
+
+    def open_select_dialog_glycerol(self):
+        dlg=OpenFilesDialog(self.parent); dlg.setWindowTitle('Select Glycerol Files')
+        if dlg.exec(): self.parent.selected_files_gly.extend(dlg.selectedFiles())
+        self.ui.btn_Start.setEnabled(True); self.ui.btn_Add.setEnabled(True)
+
+    def open_select_dialog_baseline(self):
+        dlg=OpenFilesDialog(self.parent); dlg.setWindowTitle('Select Baseline Files')
+        if dlg.exec(): self.parent.selected_files_empty.extend(dlg.selectedFiles())
+        self.ui.btn_Start.setEnabled(True); self.ui.btn_Add.setEnabled(True)

--- a/controllers/gs_controller.py
+++ b/controllers/gs_controller.py
@@ -1,9 +1,104 @@
-class GSTabController:
-    def __init__(self, main_window):
-        self.main_window = main_window
+import os
+import re
 
-    def calculate(self):
-        self.main_window.calculate_sqrt_time()
+import numpy as np
+from PySide6.QtWidgets import QMessageBox, QTableWidgetItem
 
-    def plot(self):
-        self.main_window.plot_sqrt_time()
+import Calculator as Cal
+from controllers.base_tab_controller import BaseTabController
+
+
+class GSTabController(BaseTabController):
+    def update_GS_table(self):
+        def clean_line(line):
+            while '\t\t' in line:
+                line = line.replace('\t\t', '\t')
+            return line.strip()
+
+        selected_files = self.parent.selected_GSfiles
+        table = self.ui.table_GS
+        combobox = self.ui.comboBox_7
+        pattern = r'_([0-9]+)\.dat$'
+        dictionary = self.parent.GS_dictionary
+        dictionary.clear()
+
+        try:
+            table.setRowCount(len(selected_files))
+            for row, file in zip(range(table.rowCount()), selected_files):
+                dictionary[file] = {"X Axis": [], "sqrtTime": [], "short": [], "medium": [], "long": []}
+                sqrtTime, short, medium, long = [], [], [], []
+                current_file = os.path.basename(file)
+                try:
+                    x_axis = re.search(pattern, current_file).group(1)
+                except Exception:
+                    x_axis = row
+                with open(file, "r") as data:
+                    lines = [clean_line(line.rstrip('\n')) for line in data if line.strip()]
+                for line in lines[1:]:
+                    parts = line.split('\t')
+                    sqrtTime.append(float(parts[0]))
+                    short.append(float(parts[4]))
+                    medium.append(float(parts[5]))
+                    long.append(float(parts[6]))
+                combobox.addItem(f"{current_file}")
+                table.setItem(row, 0, QTableWidgetItem(file))
+                table.setItem(row, 1, QTableWidgetItem(current_file))
+                table.setItem(row, 2, QTableWidgetItem(str(x_axis)))
+                dictionary[file]["X Axis"].append(x_axis)
+                dictionary[file]["sqrtTime"].extend(sqrtTime)
+                dictionary[file]["short"].extend(short)
+                dictionary[file]["medium"].extend(medium)
+                dictionary[file]["long"].extend(long)
+        except Exception as e:
+            QMessageBox.warning(self.parent, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
+            self.parent.clear_list()
+
+    def calculate_sqrt_time(self):
+        idx = self.ui.comboBox_7.currentIndex()
+        if idx == -1:
+            return
+        table = self.ui.table_GS
+        figure = self.ui.GS_Widget_1
+        dictionary = self.parent.GS_dictionary
+        key = table.item(idx, 0).text()
+        time_original = np.array(dictionary[key]['sqrtTime']).flatten()
+        if self.ui.checkBox_3.isChecked():
+            time_original = np.sqrt(time_original)
+        short_original = np.array(dictionary[key]['short']).flatten()
+        medium_original = np.array(dictionary[key]['medium']).flatten()
+        long_original = np.array(dictionary[key]['long']).flatten()
+        self.ui.GS_fit_from_1.setMinimum(time_original[0]); self.ui.GS_fit_from_1.setMaximum(time_original[-1])
+        self.ui.GS_fit_to_1.setMinimum(time_original[15]); self.ui.GS_fit_to_1.setMaximum(time_original[-1])
+        from_val, to_val = self.ui.GS_fit_from_1.value(), self.ui.GS_fit_to_1.value()
+        sp = (np.abs(time_original - from_val)).argmin(); ep = (np.abs(time_original - to_val)).argmin() + 1
+        time = time_original[sp:ep]
+        short = short_original[sp:ep]; medium = medium_original[sp:ep]; long = long_original[sp:ep]
+        if self.ui.radioButton_short.isChecked(): signal, signal_original = short, short_original
+        elif self.ui.radioButton_medium.isChecked(): signal, signal_original = medium, medium_original
+        else: signal, signal_original = long, long_original
+        try:
+            tf, fit, sqrtT, r2v = Cal.linear_fit_GS(time, signal)
+            d = Cal.calculate_domain_size(sqrtT, self.ui.GS_beta.value(), self.ui.GS_r2.value(), self.ui.GS_m2.value())
+            self.ui.textEdit_error_2.setText(f"R² {r2v}")
+            table.setItem(idx, 3, QTableWidgetItem(str(sqrtT)))
+            table.setItem(idx, 4, QTableWidgetItem(str(d)))
+            figure.clear(); figure.plot(time_original, signal_original, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10); figure.plot(tf, fit, pen='b')
+            dictionary[key]['sqrtT'] = sqrtT; dictionary[key]['d'] = d
+            self.ui.btn_Plot1.setEnabled(True)
+        except Exception as e:
+            figure.clear(); QMessageBox.warning(self.parent, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
+
+    def plot_sqrt_time(self):
+        table = self.ui.table_GS
+        graph = self.ui.GS_Widget_2
+        graph.clear()
+        if table.rowCount() < 1:
+            return
+        x_axis, sqrtT, n = [], [], 1
+        for row in range(table.rowCount()):
+            try: x_axis.append(float(table.item(row, 2).text()))
+            except: x_axis.append(n)
+            try: sqrtT.append(float(table.item(row, 3).text()))
+            except: sqrtT.append(0)
+            n += 1
+        graph.plot(x_axis, sqrtT, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10)

--- a/controllers/se_controller.py
+++ b/controllers/se_controller.py
@@ -1,10 +1,103 @@
-from SE_tab import SETabUIController
+from controllers.base_tab_controller import BaseTabController
+import numpy as np
+from PySide6.QtWidgets import QMessageBox
+import Calculator as Cal
 
 
-class SETabController:
-    def __init__(self, main_window):
-        self.main_window = main_window
-        self.ui_controller = SETabUIController(main_window)
+class SETabController(BaseTabController):
+    def process_processed_file(self, i, filename, amp, m2, t2, file_path):
+        match = __import__("re").search(r'.*_(-?\s*\d+\.?\d*).*.dat', filename)
+        temperature = match.group(1) if match else '0'
+        short_from = self.ui.SC_short.value() * 2
+        short_to = self.ui.SC_short_2.value() * 2
+        long_from = self.ui.SC_long.value() * 2
+        long_to = self.ui.SC_long_2.value() * 2
+        absolute = self.ui.radioButton_absolute.isChecked()
+        times = [int(short_from), int(short_to), int(long_from), int(long_to)]
+        sfc = Cal.calculate_SC(amp, times, absolute)
+        self.ui.table_SE.setRowCount(i)
+        self.parent.fill_table(self.ui.table_SE, temperature, sfc, m2, t2, i)
+        self.ui.table_SE.setItem(i - 1, 4, __import__("PySide6.QtWidgets", fromlist=["QTableWidgetItem"]).QTableWidgetItem(filename))
+        if self.ui.radioButton.isChecked():
+            self.parent.save_figures(file_path, filename)
+        self.update_graphs()
 
     def update_graphs(self):
-        self.ui_controller.update_graphs()
+        x = self.read_column_values(self.ui.table_SE, 0)
+        text = self.ui.comboBox_SE_chooseY.currentText()
+
+        if text == "SC":
+            y = self.read_column_values(self.ui.table_SE, 1)
+            self.ui.SEWidget.getAxis('left').setLabel("SC")
+        elif text == "M₂":
+            y = self.read_column_values(self.ui.table_SE, 2)
+            self.ui.SEWidget.getAxis('left').setLabel("M₂")
+        elif text == "T₂*":
+            y = self.read_column_values(self.ui.table_SE, 3)
+            self.ui.SEWidget.getAxis('left').setLabel("T₂*")
+        else:
+            self.ui.SEWidget.getAxis('left').setLabel("Not Set")
+            return
+
+        self.ui.SEWidget.clear()
+        self.ui.SEWidget.plot(
+            x, y, pen=None,
+            symbol='o', symbolPen=None,
+            symbolBrush=(255, 0, 0, 255), symbolSize=10
+        )
+
+        group_data = getattr(self.parent, "group_data_SE", {})
+        colors = getattr(self.parent, "tab10_colors", [])
+        if group_data:
+            y_col = self.ui.comboBox_SE_chooseY.currentIndex() + 1
+            for i, (_group_number, group_rows) in enumerate(group_data.items()):
+                group_x, group_y = [], []
+                for row_data in group_rows:
+                    try:
+                        group_x.append(float(row_data[0]))
+                        group_y.append(float(row_data[y_col]))
+                    except (ValueError, IndexError):
+                        continue
+                sorted_points = sorted(zip(group_x, group_y), key=lambda p: p[0])
+                if len(sorted_points) > 1:
+                    xs, ys = zip(*sorted_points)
+                    color = colors[i % len(colors)] if colors else 'r'
+                    self.ui.SEWidget.plot(
+                        xs, ys,
+                        pen={'color': color, 'width': 2},
+                        symbol='o', symbolBrush=color, symbolPen=None, symbolSize=8
+                    )
+
+    def plot_Arr(self):
+        self.ui.groupBox_EAct.setHidden(False)
+        table = self.ui.table_SE
+        graph = self.ui.SEWidget
+        Temperature = np.array(self.read_column_values(table, 0))
+        T2 = np.array(self.read_column_values(table, 3))
+        sorted_indices = np.argsort(Temperature)
+        Temperature = Temperature[sorted_indices]
+        T2 = T2[sorted_indices]
+        if self.ui.checkBox_5.isChecked():
+            Temperature = Temperature + 273.15
+        starting_point = int(self.ui.Eact_start.value())
+        ending_point = -(int(self.ui.Eact_end.value()))
+        if ending_point == 0:
+            ending_point = None
+        try:
+            Temperature = Temperature[starting_point:ending_point]
+            T2 = T2[starting_point:ending_point]
+            reciprocal_temperature, lnT2 = Cal.calculate_Arrhenius_ax(Temperature, T2)
+            Temp_fit, fitted_curve, Eact, R2 = Cal.calculate_Eact(reciprocal_temperature, lnT2, self.ui.radioButton_8.isChecked())
+            graph.clear()
+            graph.plot(reciprocal_temperature, lnT2, pen=None, symbol='o', symbolPen=None, symbolBrush=(255, 0, 0, 255), symbolSize=10)
+            graph.plot(Temp_fit, fitted_curve, pen='b')
+            self.parent.setup_graph(graph, "1000/T, 𝐾⁻¹", "ln(τ)", "")
+            self.ui.textEdit_EAct.setText(f"Eact = {Eact}\nR² {R2}")
+        except Exception as e:
+            QMessageBox.warning(self.parent, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
+
+    def hide_Eact(self):
+        self.ui.groupBox_EAct.setHidden(True)
+        self.ui.SEWidget.clear()
+        self.parent.setup_graph(self.ui.SEWidget, "", "", "")
+        self.parent.update_xaxis(self.ui.table_SE, 0)

--- a/controllers/t1t2_controller.py
+++ b/controllers/t1t2_controller.py
@@ -1,9 +1,249 @@
-class T1T2TabController:
-    def __init__(self, main_window):
-        self.main_window = main_window
+import os
+import re
+from itertools import islice
 
-    def calculate(self):
-        self.main_window.calculate_relaxation_time()
+import numpy as np
+from PySide6.QtWidgets import QMessageBox, QTableWidgetItem
 
-    def plot(self):
-        self.main_window.plot_relaxation_time()
+import Calculator as Cal
+from controllers.base_tab_controller import BaseTabController
+from dialogs.save_files_dialog import SaveFilesDialog
+
+
+class T1T2TabController(BaseTabController):
+    def update_T12_table(self):
+        def clean_line(line):
+            while '\t\t' in line:
+                line = line.replace('\t\t', '\t')
+            return line.strip()
+
+        def create_dictionary(dictionary, file, addition, x_axis, Time, Signal):
+            dictionary[file + addition]["X Axis"].append(x_axis)
+            dictionary[file + addition]["Time"].extend(Time)
+            dictionary[file + addition]["Signal"].extend(Signal)
+            return dictionary
+
+        selected_files = self.parent.selected_T1files
+        table = self.ui.table_T1
+        combobox = self.ui.T1T2_ChooseFileComboBox
+        pattern = r'(T1|T2)_(\s?-?\d+(\.\d+)?)((_.*)?\.(dat|txt))'
+        dictionary = self.parent.tau_dictionary
+        dictionary.clear()
+
+        try:
+            if os.path.splitext(selected_files[0])[1] == '.sef':
+                if os.path.splitext(selected_files[1])[1] != '.sef':
+                    QMessageBox.warning(self.parent, "Error", "Load two files: Magnetization and Profile in .sef format.", QMessageBox.Ok)
+                    return
+                if os.stat(selected_files[0]).st_size > os.stat(selected_files[1]).st_size:
+                    filetoreadzones, filetoreaddata = selected_files[1], selected_files[0]
+                else:
+                    filetoreadzones, filetoreaddata = selected_files[0], selected_files[1]
+                dictionary = self.process_files(filetoreadzones, filetoreaddata)
+                table.setRowCount(len(dictionary))
+                for row, key in zip(range(table.rowCount()), dictionary):
+                    x_axis = dictionary[key]["X Axis"]
+                    table.setItem(row, 0, QTableWidgetItem(filetoreaddata))
+                    table.setItem(row, 1, QTableWidgetItem(os.path.basename(filetoreaddata)))
+                    table.setItem(row, 2, QTableWidgetItem(x_axis))
+                    combobox.addItem(f"{x_axis}")
+                self.parent.tau_dictionary = dictionary
+                self.parent.state_bad_code = True
+
+            elif os.path.splitext(selected_files[0])[1] == '.csv':
+                self.parent.state_bad_code = False
+                table.setRowCount(len(selected_files))
+                csv_pattern = r'_(\-?\d+)(?=\.csv$)'
+                for row, file in zip(range(table.rowCount()), selected_files):
+                    current_file = os.path.basename(file)
+                    try:
+                        x_axis = re.search(csv_pattern, current_file).group(1)
+                    except Exception:
+                        x_axis = row
+                    dictionary[file] = {"X Axis": [], "Time": [], "Signal": []}
+                    Time, Signal = [], []
+                    with open(file) as f:
+                        for line in f:
+                            parts = line.strip().split(",")
+                            Time.append(float(parts[0]))
+                            Signal.append(float(parts[1]))
+                    dictionary[file]["X Axis"].append(x_axis)
+                    dictionary[file]["Time"].extend(Time)
+                    dictionary[file]["Signal"].extend(Signal)
+                    table.setItem(row, 0, QTableWidgetItem(file))
+                    table.setItem(row, 1, QTableWidgetItem(current_file))
+                    table.setItem(row, 2, QTableWidgetItem(str(x_axis)))
+                    combobox.addItem(f"{current_file}")
+
+            elif os.path.splitext(selected_files[0])[1] == '.txt':
+                self.parent.state_bad_code = False
+                table.setRowCount(len(selected_files * 4))
+                pattern_all = r'T1_.*_(\s?-?\d+).txt'
+                for file in selected_files:
+                    try:
+                        x_axis = re.search(pattern_all, os.path.basename(file)).group(1)
+                    except Exception:
+                        x_axis = 'Variable'
+                    Time, Signal_all, Signal_short, Signal_med, Signal_long = [], [], [], [], []
+                    dictionary[file + '_all'] = {"X Axis": [], "Time": [], "Signal": []}
+                    dictionary[file + '_short'] = {"X Axis": [], "Time": [], "Signal": []}
+                    dictionary[file + '_medium'] = {"X Axis": [], "Time": [], "Signal": []}
+                    dictionary[file + '_long'] = {"X Axis": [], "Time": [], "Signal": []}
+                    with open(file, "r") as data:
+                        lines = [clean_line(line.rstrip('\n')) for line in data if line.strip()]
+                        for line in lines[1:]:
+                            parts = line.split('\t')
+                            Time.append(float(parts[0]))
+                            Signal_all.append(float(parts[1]))
+                            Signal_short.append(float(parts[2]))
+                            Signal_med.append(float(parts[3]))
+                            Signal_long.append(float(parts[4]))
+                    dictionary = create_dictionary(dictionary, file, '_all', x_axis, Time, Signal_all)
+                    dictionary = create_dictionary(dictionary, file, '_short', x_axis, Time, Signal_short)
+                    dictionary = create_dictionary(dictionary, file, '_medium', x_axis, Time, Signal_med)
+                    dictionary = create_dictionary(dictionary, file, '_long', x_axis, Time, Signal_long)
+
+                for row, entry in zip(range(table.rowCount()), dictionary):
+                    current_file = os.path.basename(entry)
+                    x_axis = dictionary[entry]["X Axis"][0]
+                    table.setItem(row, 0, QTableWidgetItem(entry))
+                    table.setItem(row, 1, QTableWidgetItem(current_file))
+                    table.setItem(row, 2, QTableWidgetItem(str(x_axis)))
+                    combobox.addItem(f"{current_file}")
+            else:
+                self.parent.state_bad_code = False
+                table.setRowCount(len(selected_files))
+                for row, file in zip(range(table.rowCount()), selected_files):
+                    dictionary[file] = {"X Axis": [], "Time": [], "Signal": []}
+                    current_file = os.path.basename(file)
+                    try:
+                        x_axis = re.search(pattern, current_file).group(2)
+                    except Exception:
+                        x_axis = row
+                    try:
+                        with open(file, "r") as data:
+                            lines = [clean_line(line.rstrip('\n')) for line in data if line.strip()]
+                        Time, Signal = [], []
+                        for line in lines[1:]:
+                            parts = line.split('\t')
+                            Time.append(float(parts[0]))
+                            Signal.append(float(parts[1]))
+                    except Exception:
+                        data = np.loadtxt(file)
+                        Time, Signal = data[:, 0], data[:, 1]
+                    table.setItem(row, 0, QTableWidgetItem(file))
+                    table.setItem(row, 1, QTableWidgetItem(current_file))
+                    table.setItem(row, 2, QTableWidgetItem(str(x_axis)))
+                    dictionary[file]["X Axis"].append(x_axis)
+                    dictionary[file]["Time"].extend(Time)
+                    dictionary[file]["Signal"].extend(Signal)
+                    combobox.addItem(f"{current_file}")
+        except Exception:
+            QMessageBox.warning(self.parent, "Error", "Something went wrong. Try again.", QMessageBox.Ok)
+            self.parent.clear_list()
+
+        self.ui.btn_Plot1.setEnabled(True)
+        combobox.setCurrentIndex(-1)
+
+    def process_files(self, file1, file2):
+        zone_to_frequency = {}
+        with open(file1, 'r') as f1:
+            for line in islice(f1, 4, None):
+                parts = line.split()
+                zone_to_frequency[parts[-2]] = parts[0]
+        dictionary = {}
+        current_zone = None
+        with open(file2, 'r') as f2:
+            for line in f2:
+                line = line.strip()
+                if line.startswith("Zone"):
+                    current_zone = line.split()[1]
+                    continue
+                if not line or line.startswith("TAU") or line.startswith("---"):
+                    continue
+                if current_zone in zone_to_frequency:
+                    try:
+                        parts = line.split()
+                        time = float(parts[0]); signal = float(parts[1]); frequency = zone_to_frequency[current_zone]
+                        name = file2 + ' at freq:' + str(frequency)
+                        if name not in dictionary:
+                            dictionary[name] = {"X Axis": frequency, "Time": [], "Signal": []}
+                        dictionary[name]["Time"].append(time)
+                        dictionary[name]["Signal"].append(signal)
+                    except (ValueError, IndexError):
+                        continue
+        return dictionary
+
+    def change_exponential_order(self):
+        self.ui.DSB_ExpFitting1.setValue(100)
+        self.ui.DSB_ExpFitting2.setValue(1000)
+        self.ui.DSB_ExpFitting3.setValue(10000)
+        self.ui.DSB_ExpFitting1.setEnabled(True)
+        self.ui.DSB_ExpFitting2.setEnabled(not self.ui.T1T2_FitWith1ExpButton.isChecked())
+        self.ui.DSB_ExpFitting3.setEnabled(self.ui.T1T2_FitWith3ExpButton.isChecked())
+        self.calculate_relaxation_time()
+
+    def calculate_relaxation_time(self):
+        table = self.ui.table_T1
+        figure = self.ui.T1_Widget_1
+        idx = self.ui.T1T2_ChooseFileComboBox.currentIndex()
+        dictionary = self.parent.tau_dictionary
+        start = int(self.ui.T1T2_fit_from.value())
+        end = -(int(self.ui.T1T2_fit_to.value())) or None
+        denominator = 1 if self.ui.radioButton_16.isChecked() else 1000
+        if idx == -1:
+            return
+        if self.parent.state_bad_code:
+            key = table.item(idx, 0).text() + ' at freq:' + table.item(idx, 2).text()
+            denominator = 0.001
+        else:
+            key = table.item(idx, 0).text()
+        t0 = np.array(dictionary[key]['Time']) / denominator
+        s0 = np.array(dictionary[key]['Signal'])
+        t, s = t0[start:end], s0[start:end]
+        t1, t2, t3 = int(self.ui.DSB_ExpFitting1.value()), int(self.ui.DSB_ExpFitting2.value()), int(self.ui.DSB_ExpFitting3.value())
+        if self.ui.T1T2_FitWith1ExpButton.isChecked():
+            order, p = 1, [s[0], t1, 1]
+        elif self.ui.T1T2_FitWith2ExpButton.isChecked():
+            order, p = 2, [s[0], t1, s[0], t2, 1]
+        else:
+            order, p = 3, [s[0], t1, s[0], t2, s[0], t3, 1]
+        try:
+            tf, fit, tau1, tau2, tau3, r2, a1, a2, a3 = Cal.fit_exponent(t, s, order, p)
+        except Exception:
+            QMessageBox.warning(self.parent, "No covariance", f"I am sorry, I couldn't fit with {order} exponents. Decrease the order of fitting and try again.", QMessageBox.Ok)
+            return
+        self.ui.textEdit_error.setText(f"R² {r2}")
+        self.ui.DSB_ExpFitting1.setValue(tau1); self.ui.DSB_ExpFitting2.setValue(tau2); self.ui.DSB_ExpFitting3.setValue(tau3)
+        table.setItem(idx, 3, QTableWidgetItem(str(tau1))); table.setItem(idx, 5, QTableWidgetItem(str(tau2))); table.setItem(idx, 7, QTableWidgetItem(str(tau3)))
+        table.setItem(idx, 4, QTableWidgetItem(str(a1))); table.setItem(idx, 6, QTableWidgetItem(str(a2))); table.setItem(idx, 8, QTableWidgetItem(str(a3)))
+        figure.clear(); figure.plot(t0, s0, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10); figure.plot(tf, fit, pen='b')
+        dictionary[key]['T1 1'] = tau1; dictionary[key]['T1 2'] = tau2; dictionary[key]['T1 3'] = tau3
+        self.ui.btn_Plot1.setEnabled(True)
+
+    def plot_relaxation_time(self):
+        table = self.ui.table_T1
+        graph = self.ui.T1_Widget_2
+        column = 3 if self.ui.T1T2_1expPlotButton.isChecked() else 5 if self.ui.T1T2_2expPlotButton.isChecked() else 7
+        graph.clear()
+        if table.rowCount() < 1:
+            return
+        x_axis, relaxation_time, number = [], [], 1
+        for row in range(table.rowCount()):
+            try: x_axis.append(float(table.item(row, 2).text()))
+            except: x_axis.append(number)
+            try: relaxation_time.append(float(table.item(row, column).text()))
+            except: relaxation_time.append(0)
+            number += 1
+        graph.plot(x_axis, relaxation_time, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10)
+
+    def bad_code_makes_more_bad_code(self):
+        dictionary = self.parent.tau_dictionary
+        dialog = SaveFilesDialog(self.parent)
+        basename = os.path.basename(self.parent.selected_T1files[0])
+        save = not all(data.get('T1 1', 0) == 0 for data in dictionary.values())
+        dialog.save_file_in_sef(self.parent, dictionary, 'T1 1', 1, basename, save)
+        save = not all(data.get('T1 2', 0) == 0 for data in dictionary.values())
+        dialog.save_file_in_sef(self.parent, dictionary, 'T1 2', 2, basename, save)
+        save = not all(data.get('T1 3', 0) == 0 for data in dictionary.values())
+        dialog.save_file_in_sef(self.parent, dictionary, 'T1 3', 3, basename, save)

--- a/dialogs/open_files_dialog.py
+++ b/dialogs/open_files_dialog.py
@@ -14,7 +14,7 @@ class OpenFilesDialog(QFileDialog):
         if State_multiple_files:
             self.setFileMode(QFileDialog.ExistingFiles)  # Allow selecting multiple files
         else:
-            pass
+            self.setFileMode(QFileDialog.ExistingFile)
 
         self.setNameFilter(str("Data (*.dat *.txt *.csv *.sef)"))
 

--- a/dialogs/phasing_manual.py
+++ b/dialogs/phasing_manual.py
@@ -1,1 +1,62 @@
-"""Module scaffold for refactor."""
+import numpy as np
+from scipy.signal import savgol_filter
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QDialog
+
+import Calculator as Cal
+from ui_PhasingManual import Ui_Phasing as Ui_PhasingManual
+
+Frequency = None
+Re_spectra = None
+Im_spectra = None
+
+
+class PhasingManual(QDialog):
+    closed = Signal()
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ui = Ui_PhasingManual()
+        self.ui.setupUi(self)
+        g = self.ui.PhasingGraph
+        g.getAxis('bottom').setLabel("Frequency, MHz")
+        g.getAxis('left').setLabel("Amplitude, a.u.")
+        g.setTitle("Phasing")
+        g.addLegend()
+        self.ui.pushButton_2.clicked.connect(self.zero)
+        self.ui.verticalSlider_a.valueChanged.connect(self.value_changed)
+        self.ui.verticalSlider_b.valueChanged.connect(self.value_changed)
+        self.ui.verticalSlider_c.valueChanged.connect(self.value_changed)
+        self.ui.verticalSlider_d.valueChanged.connect(self.value_changed)
+        self.ui.dial.valueChanged.connect(self.smoothing_changed)
+        self.ui.pushButton_3.clicked.connect(self.manual_read)
+        self.ui.pushButton.clicked.connect(self.save_data)
+        self.Real_freq_phased = None
+
+    def read_data(self): self.zero()
+    def save_data(self): self.close()
+    def closeEvent(self, event): self.closed.emit(); super().closeEvent(event)
+    def zero(self):
+        self.a=self.b=self.c=self.d=self.Smooth=0
+        for s,b in [(self.ui.verticalSlider_a,self.ui.Box_a),(self.ui.verticalSlider_b,self.ui.Box_b),(self.ui.verticalSlider_c,self.ui.Box_c),(self.ui.verticalSlider_d,self.ui.Box_d)]: s.setValue(0); b.setValue(0)
+        self.ui.dial.setValue(0); self.ui.Box_smooth.setValue(0)
+        if self.Real_freq_phased is not None: self.process_data()
+    def process_data(self): self.Real_freq_phased=self.calculate_phase(); self.update_plot(); self.update_text()
+    def calculate_phase(self):
+        phi=self.a+self.b*Frequency+self.c*Frequency**2+self.d*Frequency**3
+        y=Re_spectra*np.cos(np.deg2rad(phi))-Im_spectra*np.sin(np.deg2rad(phi))
+        if self.Smooth>1: y=savgol_filter(y, window_length=int(self.Smooth), polyorder=1)
+        return y
+    def update_plot(self):
+        self.ui.PhasingGraph.clear(); self.ui.PhasingGraph.plot(Frequency, Re_spectra, pen='r', name='Original'); self.ui.PhasingGraph.plot(Frequency, self.Real_freq_phased, pen='b', name='Phased')
+    def update_text(self):
+        Integral=np.trapz(self.Real_freq_phased); delta=np.mean(self.Real_freq_phased[:100])-np.mean(self.Real_freq_phased[-100:])
+        self.ui.Integral.setText(f"Integral: {round(Integral,3)}"); self.ui.Delta.setText(f"Delta: {round(delta,7)}")
+        M2,T2=Cal._calculate_M2(Cal._calculate_apodization(self.Real_freq_phased, Frequency), Frequency)
+        self.ui.M2.setText(f"M₂: {round(M2,5)}"); self.ui.T2.setText(f"T₂*: {round(T2,3)}")
+    def value_changed(self):
+        self.a=self.ui.verticalSlider_a.value(); self.b=self.ui.verticalSlider_b.value(); self.c=self.ui.verticalSlider_c.value(); self.d=self.ui.verticalSlider_d.value()
+        self.ui.Box_a.setValue(self.a); self.ui.Box_b.setValue(self.b); self.ui.Box_c.setValue(self.c); self.ui.Box_d.setValue(self.d)
+        if Frequency is not None and Re_spectra is not None and Im_spectra is not None: self.process_data()
+    def smoothing_changed(self): self.Smooth=self.ui.dial.value(); self.ui.Box_smooth.setValue(self.Smooth); self.process_data()
+    def manual_read(self):
+        self.a=self.ui.Box_a.value(); self.b=self.ui.Box_b.value(); self.c=self.ui.Box_c.value(); self.d=self.ui.Box_d.value(); self.Smooth=self.ui.Box_smooth.value(); self.process_data()

--- a/dialogs/save_files_dialog.py
+++ b/dialogs/save_files_dialog.py
@@ -1,0 +1,57 @@
+import json
+import os
+import sys
+import winreg
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+
+class SaveFilesDialog(QFileDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptMode(QFileDialog.AcceptSave)
+
+    def save_data_as_csv(self, directory, table, files, default_filename):
+        try:
+            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\MyApp", 0, winreg.KEY_READ)
+            directory, _ = winreg.QueryValueEx(key, "SelectedFolder")
+            winreg.CloseKey(key)
+        except Exception:
+            directory = os.path.dirname(sys.argv[0])
+
+        options = QFileDialog.Options()
+        file_path, _ = QFileDialog.getSaveFileName(self, "Save File As", directory + '/' + default_filename, "CSV files (*.csv)", options=options)
+        if file_path:
+            with open(file_path, 'w') as f:
+                for row in range(table.rowCount()):
+                    row_values = []
+                    for col in range(table.columnCount()):
+                        item = table.item(row, col)
+                        row_values.append(item.text() if item is not None else "")
+                    f.write(','.join(row_values) + '\n')
+            files_list_path = os.path.splitext(file_path)[0] + '_files.json'
+            with open(files_list_path, 'w') as file_list:
+                json.dump(files, file_list)
+
+    def save_file_in_sef(self, wtf, dictionary, tau, n, begin, save):
+        if not save:
+            return
+        try:
+            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\MyApp", 0, winreg.KEY_READ)
+            directory, _ = winreg.QueryValueEx(key, "SelectedFolder")
+            winreg.CloseKey(key)
+        except Exception:
+            directory = os.path.dirname(sys.argv[0])
+        try:
+            options = QFileDialog.Options()
+            default_add = '_recalculated_tau_' + str(n)
+            file_path, _ = QFileDialog.getSaveFileName(self, "Save File As", directory + '/' + begin + default_add, "SEF files (*.sef)", options=options)
+            with open(file_path, 'w') as f:
+                f.write('STELAR Export File\n\n')
+                f.write('_BRLX______\t_T1________\t_R1________\t____%err___\t+-err(R1)__\tZone\tFile\n\n')
+                for key in dictionary:
+                    Frequency = dictionary[key]['X Axis']
+                    T1 = dictionary[key][tau]
+                    Omega_1 = 0 if T1 == 0 else 1000 / T1
+                    f.write(f'{Frequency}\t{T1}\t{Omega_1}\n')
+        except Exception:
+            QMessageBox.warning(self, "Save failed", "Sorry, couldn't save the separate file in .sef for magnetization.", QMessageBox.Ok)

--- a/logging_system.py
+++ b/logging_system.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+
+
+def _is_repo_code(filename: str) -> bool:
+    if not filename:
+        return False
+    parts = Path(filename).parts
+    skip = {"site-packages", "lib-dynload", "importlib", "encodings"}
+    return not any(p in skip for p in parts)
+
+
+def _format_file_lengths(frame):
+    hints = []
+    for name, value in frame.f_locals.items():
+        lower = name.lower()
+        if "file" not in lower:
+            continue
+        if isinstance(value, (list, tuple)):
+            hints.append(f"{name}:len={len(value)}")
+        elif isinstance(value, str):
+            size = None
+            if os.path.exists(value) and os.path.isfile(value):
+                try:
+                    size = os.path.getsize(value)
+                except OSError:
+                    size = None
+            if size is not None:
+                hints.append(f"{name}:path,size={size}")
+            else:
+                hints.append(f"{name}:str")
+    return ", ".join(hints)
+
+
+def _profile(frame, event, arg):
+    if event != "call":
+        return _profile
+    code = frame.f_code
+    filename = code.co_filename
+    if not _is_repo_code(filename):
+        return _profile
+    fn = code.co_name
+    details = _format_file_lengths(frame)
+    if details:
+        print(f"[TRACE] {fn} | {details}")
+    else:
+        print(f"[TRACE] {fn}")
+    return _profile
+
+
+def install_function_logger():
+    sys.setprofile(_profile)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import sys
 from PySide6.QtWidgets import QApplication
 from main_window import MainWindow
+from logging_system import install_function_logger
 
 
 def main():
+    install_function_logger()
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()

--- a/main_window.py
+++ b/main_window.py
@@ -13,16 +13,19 @@ import pyqtgraph as pg
 from pyqtgraph import mkPen, ColorMap, mkColor, InfiniteLine
 import pyqtgraph.exporters
 from ui_Form import Ui_NMR
-from ui_PhasingManual import Ui_Phasing as Ui_PhasingManual
 import Calculator as Cal # Mathematical procedures
 from controllers import (
     SETabController, DQTabController, DQTempTabController,
-    T1T2TabController, DQMQTabController, GSTabController, ExtraTabController
+    T1T2TabController, DQMQTabController, GSTabController, GeneralSEDQController
 )
 from dialogs.open_files_dialog import OpenFilesDialog
+import dialogs.open_files_dialog as open_files_dialog_module
 from dialogs.notification_dialog import NotificationDialog
 from dialogs.group_window import GroupWindow
+from dialogs.save_files_dialog import SaveFilesDialog
+from dialogs.phasing_manual import PhasingManual
 from widgets.table_copy_enabler import TableCopyEnabler
+from app_state import AppState
 
 pg.CONFIG_OPTIONS['background'] = 'w'
 pg.CONFIG_OPTIONS['foreground'] = 'k'
@@ -31,11 +34,6 @@ pg.CONFIG_OPTIONS['foreground'] = 'k'
 # here is the generous example of the masterpiece in bad coding.
 # but it works and I don't care
 
-# Global
-Frequency = []
-Re_spectra = []
-Im_spectra = []
-State_multiple_files = None
 
 class MainWindow(QMainWindow):
     def __init__(self, parent=None):
@@ -57,13 +55,17 @@ class MainWindow(QMainWindow):
         # Maximize minimize
         self.setWindowFlags(self.windowFlags() | self.windowFlags().WindowMaximizeButtonHint)
 
+        self.app_state = AppState()
+
         self.selected_files = []
         self.selected_files_DQ_single = []
+        self.app_state.dq_files = self.selected_files_DQ_single
         self.selected_files_gly = []
         self.selected_files_empty = []
         self.selected_DQfiles = []
         self.selected_T1files = []
         self.selected_DQMQfile = []
+        self.app_state.dqmq_files = self.selected_DQMQfile
         self.selected_GSfiles = []
         self.window_array = np.array([])
         self.dq_t2 = {}
@@ -76,13 +78,17 @@ class MainWindow(QMainWindow):
         self.group_data_SD = {}
         self.tab = None
         self.state_bad_code = False
-        self.se_controller = SETabController(self)
-        self.dq_controller = DQTabController(self)
-        self.dq_temp_controller = DQTempTabController(self)
-        self.t1t2_controller = T1T2TabController(self)
-        self.dqmq_controller = DQMQTabController(self)
-        self.gs_controller = GSTabController(self)
-        self.extra_controller = ExtraTabController(self)
+        self.se_controller = SETabController(ui=self.ui, state=self.app_state, parent=self)
+        self.dq_controller = DQTabController(
+            ui=self.ui,
+            state=self.app_state,
+            parent=self,
+        )
+        self.dq_temp_controller = DQTempTabController(ui=self.ui, state=self.app_state, parent=self)
+        self.t1t2_controller = T1T2TabController(ui=self.ui, state=self.app_state, parent=self)
+        self.dqmq_controller = DQMQTabController(ui=self.ui, state=self.app_state, parent=self)
+        self.gs_controller = GSTabController(ui=self.ui, state=self.app_state, parent=self)
+        self.general_se_dq_controller = GeneralSEDQController(ui=self.ui, state=self.app_state, parent=self, se_controller=self.se_controller, dq_controller=self.dq_controller)
 
         self.state()
 
@@ -104,7 +110,7 @@ class MainWindow(QMainWindow):
         self.ui.btn_Load_3.clicked.connect(self.load_data)
         self.ui.btn_Load_4.clicked.connect(self.load_data)
         self.ui.btn_Load_5.clicked.connect(self.load_data)
-        self.ui.btn_Phasing.clicked.connect(self.open_phasing_manual)
+        self.ui.btn_Phasing.clicked.connect(self.general_se_dq_controller.open_phasing_manual)
 
         self.ui.btn_SelectFiles.clicked.connect(self.open_select_dialog)
         self.ui.btn_Add.clicked.connect(self.add_select_dialog)
@@ -124,17 +130,17 @@ class MainWindow(QMainWindow):
         self.ui.btn_DeleteRow_2.clicked.connect(self.delete_row)
         self.ui.btn_DeleteRow_3.clicked.connect(self.delete_row)
 
-        self.ui.btn_Start.clicked.connect(self.analysis)
+        self.ui.btn_Start.clicked.connect(self.general_se_dq_controller.analysis)
 
-        self.ui.pushButton_DQMQ_1.clicked.connect(self.plot_original)
-        self.ui.radioButton_Log.clicked.connect(self.plot_fit)
-        self.ui.pushButton_DQMQ_4.clicked.connect(self.plot_norm)
-        self.ui.pushButton_DQMQ_2.clicked.connect(self.plot_diff)
-        self.ui.pushButton_DQMQ_3.clicked.connect(self.plot_nDQ)
-        self.ui.btn_Plot1.clicked.connect(self.plot_relaxation_time)
-        self.ui.btn_Plot_GS.clicked.connect(self.plot_sqrt_time)
+        self.ui.pushButton_DQMQ_1.clicked.connect(self.dqmq_controller.plot_original)
+        self.ui.radioButton_Log.clicked.connect(self.dq_controller.plot_fit)
+        self.ui.pushButton_DQMQ_4.clicked.connect(self.dqmq_controller.plot_norm)
+        self.ui.pushButton_DQMQ_2.clicked.connect(self.dqmq_controller.plot_diff)
+        self.ui.pushButton_DQMQ_3.clicked.connect(self.dqmq_controller.plot_nDQ)
+        self.ui.btn_Plot1.clicked.connect(self.t1t2_controller.plot_relaxation_time)
+        self.ui.btn_Plot_GS.clicked.connect(self.gs_controller.plot_sqrt_time)
 
-        self.ui.pushButton_Eact.clicked.connect(self.plot_Arr)
+        self.ui.pushButton_Eact.clicked.connect(self.se_controller.plot_Arr)
 
         self.ui.pushButton_GroupSE.clicked.connect(self.open_group_window)
         self.ui.pushButton_GroupT1T2.clicked.connect(self.open_group_window)
@@ -172,49 +178,49 @@ class MainWindow(QMainWindow):
     lambda index=2: self.renameSection(self.ui.table_DQ_2, index=1)
 )
         # Connect table signals to slots
-        self.ui.table_DQ.currentItemChanged.connect(self.update_dq_graphs)
-        self.ui.T1T2_FitWith1ExpButton.clicked.connect(self.change_exponential_order)
-        self.ui.T1T2_FitWith2ExpButton.clicked.connect(self.change_exponential_order)
-        self.ui.T1T2_FitWith3ExpButton.clicked.connect(self.change_exponential_order)
+        self.ui.table_DQ.currentItemChanged.connect(self.dq_controller.update_graphs)
+        self.ui.T1T2_FitWith1ExpButton.clicked.connect(self.t1t2_controller.change_exponential_order)
+        self.ui.T1T2_FitWith2ExpButton.clicked.connect(self.t1t2_controller.change_exponential_order)
+        self.ui.T1T2_FitWith3ExpButton.clicked.connect(self.t1t2_controller.change_exponential_order)
 
-        self.ui.radioButton_16.clicked.connect(self.calculate_relaxation_time)
-        self.ui.radioButton_17.clicked.connect(self.calculate_relaxation_time)
-        self.ui.T1T2_fit_from.valueChanged.connect(self.calculate_relaxation_time)
-        self.ui.T1T2_fit_to.valueChanged.connect(self.calculate_relaxation_time)
+        self.ui.radioButton_16.clicked.connect(self.t1t2_controller.calculate_relaxation_time)
+        self.ui.radioButton_17.clicked.connect(self.t1t2_controller.calculate_relaxation_time)
+        self.ui.T1T2_fit_from.valueChanged.connect(self.t1t2_controller.calculate_relaxation_time)
+        self.ui.T1T2_fit_to.valueChanged.connect(self.t1t2_controller.calculate_relaxation_time)
 
-        self.ui.checkBox_3.clicked.connect(self.calculate_sqrt_time)
-        self.ui.radioButton_short.clicked.connect(self.calculate_sqrt_time)
-        self.ui.radioButton_medium.clicked.connect(self.calculate_sqrt_time)
-        self.ui.radioButton_long.clicked.connect(self.calculate_sqrt_time)
-        self.ui.GS_fit_from_1.valueChanged.connect(self.calculate_sqrt_time)
-        self.ui.GS_fit_to_1.valueChanged.connect(self.calculate_sqrt_time)
+        self.ui.checkBox_3.clicked.connect(self.gs_controller.calculate_sqrt_time)
+        self.ui.radioButton_short.clicked.connect(self.gs_controller.calculate_sqrt_time)
+        self.ui.radioButton_medium.clicked.connect(self.gs_controller.calculate_sqrt_time)
+        self.ui.radioButton_long.clicked.connect(self.gs_controller.calculate_sqrt_time)
+        self.ui.GS_fit_from_1.valueChanged.connect(self.gs_controller.calculate_sqrt_time)
+        self.ui.GS_fit_to_1.valueChanged.connect(self.gs_controller.calculate_sqrt_time)
 
-        self.ui.GS_beta.valueChanged.connect(self.calculate_sqrt_time)
-        self.ui.GS_r2.valueChanged.connect(self.calculate_sqrt_time)
-        self.ui.GS_m2.valueChanged.connect(self.calculate_sqrt_time)
+        self.ui.GS_beta.valueChanged.connect(self.gs_controller.calculate_sqrt_time)
+        self.ui.GS_r2.valueChanged.connect(self.gs_controller.calculate_sqrt_time)
+        self.ui.GS_m2.valueChanged.connect(self.gs_controller.calculate_sqrt_time)
 
         # Connect combobox signals to slots
         self.ui.comboBox_SE_chooseY.activated.connect(self.update_se_graphs)
-        self.ui.comboBox_FunctionDQ.activated.connect(self.plot_fit)
-        self.ui.T1T2_ChooseFileComboBox.activated.connect(self.calculate_relaxation_time)
-        self.ui.comboBox_7.activated.connect(self.calculate_sqrt_time)
+        self.ui.comboBox_FunctionDQ.activated.connect(self.dq_controller.plot_fit)
+        self.ui.T1T2_ChooseFileComboBox.activated.connect(self.t1t2_controller.calculate_relaxation_time)
+        self.ui.comboBox_7.activated.connect(self.gs_controller.calculate_sqrt_time)
 
         # Eact
-        self.ui.radioButton_7.clicked.connect(self.plot_Arr)
-        self.ui.radioButton_8.clicked.connect(self.plot_Arr)
-        self.ui.checkBox_5.clicked.connect(self.plot_Arr)
-        self.ui.Eact_start.valueChanged.connect(self.plot_Arr)
-        self.ui.Eact_end.valueChanged.connect(self.plot_Arr)
-        self.ui.pushButton_Done.clicked.connect(self.hide_Eact)
+        self.ui.radioButton_7.clicked.connect(self.se_controller.plot_Arr)
+        self.ui.radioButton_8.clicked.connect(self.se_controller.plot_Arr)
+        self.ui.checkBox_5.clicked.connect(self.se_controller.plot_Arr)
+        self.ui.Eact_start.valueChanged.connect(self.se_controller.plot_Arr)
+        self.ui.Eact_end.valueChanged.connect(self.se_controller.plot_Arr)
+        self.ui.pushButton_Done.clicked.connect(self.se_controller.hide_Eact)
 
 
         # Connect change events
-        self.ui.dq_min.valueChanged.connect(self.update_dq_graphs)
-        self.ui.dq_max.valueChanged.connect(self.update_dq_graphs)
+        self.ui.dq_min.valueChanged.connect(self.dq_controller.update_graphs)
+        self.ui.dq_max.valueChanged.connect(self.dq_controller.update_graphs)
         self.ui.comboBox_4.activated.connect(self.update_file)
-        self.ui.dq_min_3.valueChanged.connect(self.plot_diff)
-        self.ui.dq_max_3.valueChanged.connect(self.plot_diff)
-        self.ui.power.valueChanged.connect(self.plot_diff)
+        self.ui.dq_min_3.valueChanged.connect(self.dqmq_controller.plot_diff)
+        self.ui.dq_max_3.valueChanged.connect(self.dqmq_controller.plot_diff)
+        self.ui.power.valueChanged.connect(self.dqmq_controller.plot_diff)
 
         # Disable buttons initially
         self.disable_buttons()
@@ -304,7 +310,7 @@ class MainWindow(QMainWindow):
         # Update general figures
         if self.tab == 'DQ':
             self.highlight_row(self.ui.table_DQ, i)
-            self.update_dq_graphs()
+            self.dq_controller.update_graphs()
         elif self.tab == 'SE':
             self.highlight_row(self.ui.table_SE, i)
             self.update_se_graphs()
@@ -313,6 +319,7 @@ class MainWindow(QMainWindow):
 
     def clear_list(self):
         if self.tab == 'SE':
+            self.app_state = AppState()
             self.selected_files = []
             self.selected_files_gly = []
             self.selected_files_empty = []
@@ -324,6 +331,7 @@ class MainWindow(QMainWindow):
             self.group_data_SE = {}
         elif self.tab == 'DQ':
             self.selected_files_DQ_single = []
+            self.app_state.dq_files = []
             self.selected_files_gly = []
             self.selected_files_empty = []
             self.ui.table_DQ.setRowCount(0)
@@ -349,6 +357,7 @@ class MainWindow(QMainWindow):
             self.group_data_T1T2 = {}
         elif self.tab == 'DQMQ':
             self.selected_DQMQfile = []
+            self.app_state.dqmq_files = []
         elif self.tab == 'GS':
             self.selected_GSfiles = []
             self.GS_dictionary = {}
@@ -430,38 +439,35 @@ class MainWindow(QMainWindow):
         graph_widget.setTitle(title)
 
     def open_select_comparison_files_dialog(self):
-        global State_multiple_files
-
         if self.tab == 'DQMQ':
-            State_multiple_files = False
+            open_files_dialog_module.State_multiple_files = False
         else:
-            State_multiple_files = True
+            open_files_dialog_module.State_multiple_files = True
 
         dlg = OpenFilesDialog(self)
         if dlg.exec():
             if self.tab == 'DQ_Temp':
                 DQfileNames = dlg.selectedFiles()
                 self.selected_DQfiles.extend(DQfileNames)
-                self.update_DQ_comparison()
+                self.dq_temp_controller.update_DQ_comparison()
             elif self.tab == 'T1T2':
                 while self.ui.T1T2_ChooseFileComboBox.count()>0:
                     self.ui.T1T2_ChooseFileComboBox.removeItem(0)
                 T1fileNames = dlg.selectedFiles()
                 self.selected_T1files.extend(T1fileNames)
-                self.update_T12_table()
+                self.t1t2_controller.update_T12_table()
             elif self.tab == 'GS':
                 while self.ui.comboBox_7.count()>0:
                     self.ui.comboBox_7.removeItem(0)
                 GSfileNames = dlg.selectedFiles()
                 self.selected_GSfiles.extend(GSfileNames)
-                self.update_GS_table()
+                self.gs_controller.update_GS_table()
             elif self.tab == 'DQMQ':
                 self.selected_DQMQfile = dlg.selectedFiles()
-                self.dq_mq_analysis()
+                self.dqmq_controller.dq_mq_analysis()
 
     def open_select_dialog(self):
-        global State_multiple_files
-        State_multiple_files = True
+        open_files_dialog_module.State_multiple_files = True
         dlg = OpenFilesDialog(self)
 
         if dlg.exec():
@@ -477,10 +483,10 @@ class MainWindow(QMainWindow):
             self.selected_files = files
         else:
             self.selected_files_DQ_single = files
+            self.app_state.dq_files = files
 
     def add_select_dialog(self):
-        global State_multiple_files
-        State_multiple_files = True
+        open_files_dialog_module.State_multiple_files = True
         dlg = OpenFilesDialog(self)
 
         if self.tab == 'SE':
@@ -499,31 +505,7 @@ class MainWindow(QMainWindow):
             self.selected_files = files
         else:
             self.selected_files_DQ_single = files
-
-    def open_select_dialog_glycerol(self):
-        dlg = OpenFilesDialog(self)
-        dlg.setWindowTitle("Select Glycerol Files")
-        if dlg.exec():
-            fileNames_gly = dlg.selectedFiles()
-            self.selected_files_gly.extend(fileNames_gly)
-        self.ui.btn_Start.setEnabled(True)
-        self.ui.btn_Add.setEnabled(True)
-
-    def open_select_dialog_baseline(self):
-        dlg = OpenFilesDialog(self)
-        dlg.setWindowTitle("Select Baseline Files")
-        if dlg.exec():
-            fileNames_empty = dlg.selectedFiles()
-            self.selected_files_empty.extend(fileNames_empty)
-        self.ui.btn_Start.setEnabled(True)
-        self.ui.btn_Add.setEnabled(True)
-
-    def open_phasing_manual(self):
-        self.phasing_manual_window = PhasingManual()
-        self.phasing_manual_window.read_data()
-        self.phasing_manual_window.show()
-
-        self.phasing_manual_window.closed.connect(self.after_phasing)
+            self.app_state.dq_files = files
 
     def open_group_window(self):
         self.group_window = GroupWindow()
@@ -550,11 +532,11 @@ class MainWindow(QMainWindow):
 
         elif self.tab == 'T1T2':
             self.group_data_T1T2 = data
-            self.plot_relaxation_time()
+            self.t1t2_controller.plot_relaxation_time()
 
         elif self.tab == 'GS':
             self.group_data_SD = data
-            self.plot_sqrt_time()
+            self.gs_controller.plot_sqrt_time()
 
     def state(self):
         current_tab_index =  self.ui.tabWidget.currentIndex()
@@ -628,236 +610,6 @@ class MainWindow(QMainWindow):
             table.horizontalHeaderItem(index).setText(new_header)
             self.update_xaxis(table, index)
 
-    # All these functions refer to the general analysis where FFT and FID are produced
-    def analysis(self):
-        # Clear Combobox
-        while self.ui.comboBox_4.count()>0:
-            self.ui.comboBox_4.removeItem(0)
-
-        if self.tab == 'SE':
-            files = self.selected_files
-            self.ui.SEWidget.clear()
-            self.ui.comboBox_SE_chooseY.setCurrentIndex(-1)
-        else:
-            files = self.selected_files_DQ_single
-            self.ui.DQ_Widget_1.clear()
-            self.ui.DQ_Widget_2.clear()
-            self.ui.DQ_Widget_4.clear()
-            self.ui.textEdit_4.setText("")
-            self.ui.comboBox_FunctionDQ.setCurrentIndex(-1)
-
-        if (len(files)==0):
-            return
-
-        if self.ui.checkBox_glycerol.isChecked():
-            if self.selected_files_gly == []:
-                self.open_select_dialog_glycerol()
-                if len(self.selected_files_gly) < len(files):
-                    QMessageBox.warning(self, "Invalid Data", f"The amount of Glycerol files is not the same as sample files. Adding glycerol files automatically.", QMessageBox.Ok)
-                    last_file = self.selected_files_gly[-1]
-                    num_to_add = len(files) - len(self.selected_files_gly)
-                    self.selected_files_gly.extend([last_file] * num_to_add)
-        else:
-            self.selected_files_gly = []
-
-        if self.ui.checkBox_baseline.isChecked():
-            if self.selected_files_empty == []:
-                self.open_select_dialog_baseline()
-                if len(self.selected_files_empty) < len(files):
-                    QMessageBox.warning(self, "Invalid Data", f"The amount of Empty files is not the same as sample files. Adding baseline files automatically.", QMessageBox.Ok)
-                    last_file = self.selected_files_empty[-1]
-                    num_to_add = len(files) - len(self.selected_files_empty)
-                    self.selected_files_empty.extend([last_file] * num_to_add)
-        else:
-            self.selected_files_empty = []
-
-        self.disable_buttons()
-        self.ui.btn_SelectFiles.setEnabled(False)
-        self.ui.btn_Load.setEnabled(False)
-        self.ui.radioButton.setEnabled(False)
-        self.ui.comboBox_4.setCurrentIndex(-1)
-
-        if self.ui.checkBox_Smooth.isChecked():
-            window_first_value = self.ui.SmoothWindowFrom.value()
-            window_last_value = self.ui.SmoothWindowTo.value()
-            self.window_array = np.linspace(window_first_value, window_last_value, len(files), dtype=np.int32)
-        else:
-            self.window_array = np.array([])
-
-        for i, file_path in enumerate(files, start=1):
-
-            if self.ui.checkBox_glycerol.isChecked():
-                file_path_gly = self.selected_files_gly[i-1]
-            else:
-                file_path_gly = []
-            if self.ui.checkBox_baseline.isChecked():
-                file_path_empty = self.selected_files_empty[i-1]
-            else:
-                file_path_empty = []
-
-            try:
-                self.process_file_data(file_path, file_path_gly, file_path_empty, i)
-            except:
-                self.analysis_error(file_path, files)
-                # return
-
-        self.update_legends_and_dq_graphs()
-        self.ui.btn_Start.setStyleSheet("background-color: none")
-
-        if self.ui.radioButton.isChecked():
-            QMessageBox.information(self, "Data Saved", f"The figures have been saved to {os.path.dirname(file_path) + '/Result'}", QMessageBox.Ok)
-
-    def analysis_error(self, file_path, files):
-        QMessageBox.warning(self, "Invalid Data", f"Couldn't read the {os.path.basename(file_path)}. Deleting the file.", QMessageBox.Ok)
-        files.remove(file_path)
-        self.ui.btn_SelectFiles.setEnabled(True)
-        self.ui.btn_Start.setStyleSheet("background-color: none")
-
-        self.ui.FidWidget.clear()
-        self.ui.FFTWidget.clear()
-        self.ui.btn_Phasing.setEnabled(False)
-        self.enable_buttons()
-        # self.analysis()
-
-    def update_legends_and_dq_graphs(self):
-        self.enable_buttons()
-
-        if self.tab == 'DQ':
-            self.update_dq_graphs()
-
-    def process_file_data(self, file_path, file_path_gly, file_path_empty, i):
-        global Frequency, Re_spectra, Im_spectra
-
-        # Read name of filename
-        filename = os.path.basename(file_path)
-
-        if self.ui.checkBox_baseline.isChecked():
-            subtract = True
-        else:
-            subtract = False
-
-        # Read data
-        data = np.loadtxt(file_path)
-        x, y, z = data[:, 0], data[:, 1], data[:, 2]
-
-        Time, Re, Im = Cal.analysis_time_domain(file_path, file_path_empty, subtract)
-
-        if self.ui.checkBox_glycerol.isChecked():
-            # Glycerol
-            Time_r, Re_r, Im_r = Cal.analysis_time_domain(file_path_gly, [], False)
-            Time, Re, Im = Cal.magnet_inhomogenity_correction(Time, Time_r, Re, Re_r, Im, Im_r)
-
-        if self.ui.checkBox_long_component.isChecked():
-            # Longcomponent
-            Time, Re, Im = Cal.subtract_long_component(Time, Re, Im)
-
-        Amp = Cal._calculate_amplitude(Re, Im)
-        self.update_graphs(Time, Amp, Re, Im, self.ui.FidWidget)
-
-        number_of_points = 2**16
-
-        Time_fid, Fid =  Cal.final_analysis_time_domain(Time, Re, Im, number_of_points)
-        Frequency = Cal._calculate_frequency_scale(Time_fid)
-
-        if len(Frequency) < len(Fid):
-            diff = len(Fid) - len(Frequency)
-            df = Frequency[1] - Frequency[0]
-            extra_freq = Frequency[-1] + np.arange(1, diff+1) * df
-            Frequency = np.concatenate([Frequency, extra_freq])
-        elif len(Frequency) > len(Fid):
-            Frequency = Frequency[:len(Fid)]
-
-
-        FFT = np.fft.fftshift(np.fft.fft(Fid))
-
-        if not self.window_array.size == 0:
-            try:
-                window = self.window_array[i-1]
-                RealPart = savgol_filter(np.real(FFT), window, polyorder=1)
-                ImaginaryPart = savgol_filter(np.imag(FFT), window, polyorder=1)
-                FFT = np.array(RealPart + 1j * ImaginaryPart)
-            except Exception as e:
-                print(f'Couldnt smooth because {e}')
-
-        # 8. Simple baseline
-        Amp_spectra, Re_spectra, Im_spectra = Cal._simple_baseline_correction(FFT)
-        # 9. Cal.apodization
-        Real_apod = Cal._calculate_apodization(Re_spectra, Frequency)
-
-
-        # Update FFT graphs
-        self.update_graphs(Frequency, Amp_spectra, Re_spectra, Im_spectra, self.ui.FFTWidget)
-        if self.ui.comboBox_4.findText(filename) == -1:
-            self.ui.comboBox_4.addItem(filename)
-
-        if self.ui.comboBox_4.currentIndex() == -1:
-            M2, T2 = Cal._calculate_M2(Real_apod, Frequency)
-
-            if self.tab == 'SE':
-                match = re.search(r'.*_(-?\s*\d+\.?\d*).*.dat', filename)
-                temperature = self.extract_info(match)
-
-                short_from = self.ui.SC_short.value() *2
-                short_to = self.ui.SC_short_2.value() *2
-
-                long_from = self.ui.SC_long.value() *2
-                long_to = self.ui.SC_long_2.value() *2
-
-                absolute = self.ui.radioButton_absolute.isChecked()
-                times = [int(short_from), int(short_to), int(long_from), int(long_to)]
-
-                SFC = Cal.calculate_SC(Amp, times, absolute)
-                self.ui.table_SE.setRowCount(i) # HERE to set the right amount of rows
-                self.fill_table(self.ui.table_SE, temperature, SFC, M2, T2, i)
-
-                self.ui.table_SE.setItem(i-1, 4, QTableWidgetItem(filename))
-
-                if self.ui.radioButton.isChecked():
-                    self.save_figures(file_path, filename)
-
-            elif self.tab == 'DQ':
-                match = re.search(r'_(\d+\.\d+)_', filename)
-                dq_time = self.extract_info(match)
-
-                Amplitude = Cal._calculate_amplitude(y, z)
-                DQ = Cal.calculate_DQ_intensity(x, Amplitude)
-                self.ui.table_DQ.setRowCount(i)
-                self.fill_table(self.ui.table_DQ, dq_time, DQ, M2, T2, i)
-
-                if self.ui.radioButton.isChecked():
-                    self.save_figures(file_path, dq_time)
-        else:
-            pass
-
-    def after_phasing(self):
-        global Frequency, Re_spectra, Im_spectra
-
-        i = self.ui.comboBox_4.currentIndex()
-
-        Real_apod   = Cal._calculate_apodization(Re_spectra, Frequency) #(math procedure)
-        Amp_spectra = Cal._calculate_amplitude(Re_spectra, Im_spectra)
-
-        # Update FFT graph
-        self.update_graphs(Frequency, Amp_spectra, Re_spectra, Im_spectra, self.ui.FFTWidget)
-
-        M2, T2 = Cal._calculate_M2(Real_apod, Frequency)
-        M2_r = round(M2, 6)
-        T2_r = round(T2, 6)
-
-        if self.tab == 'SE':
-            table = self.ui.table_SE
-        elif self.tab == 'DQ':
-            table = self.ui.table_DQ
-
-
-        table.setItem(i, 2, QTableWidgetItem(str(M2_r)))
-        table.setItem(i, 3, QTableWidgetItem(str(T2_r)))
-
-        if self.tab == 'SE':
-            self.update_se_graphs()
-        elif self.tab == 'DQ':
-            self.update_dq_graphs()
-
     def extract_info(self, pattern):
         if pattern:
             info = pattern.group(1)
@@ -892,923 +644,6 @@ class MainWindow(QMainWindow):
     def update_se_graphs(self):
         self.se_controller.update_graphs()
 
-    # Working with DQ graphs
-    def update_dq_graphs(self):
-        self.dq_controller.update_graphs()
-
-    def dq_t2_graph(self):
-        x = self.read_column_values(self.ui.table_DQ, 0)
-        y= self.read_column_values(self.ui.table_DQ, 3)
-        self.ui.DQ_Widget_1.clear()
-        self.ui.DQ_Widget_1.plot(x, y, pen=None, symbol='o', symbolPen=None, symbolBrush=(255, 0, 0, 255), symbolSize=10)
-
-    def linearization(self):
-        # Calculate line
-        time_min = self.ui.dq_min.value()
-        time_max = self.ui.dq_max.value()
-        dq_time = np.array(self.read_column_values(self.ui.table_DQ, 0))
-        t2 = np.array(self.read_column_values(self.ui.table_DQ, 3))
-        dq = np.array(self.read_column_values(self.ui.table_DQ, 1))
-
-        x = dq_time[(dq_time >= time_min) & (dq_time <= time_max)]
-        if len(x) < 3:
-            time_min = 0
-            time_max = 20
-            self.ui.dq_min.setValue(time_min)
-            self.ui.dq_max.setValue(time_max)
-            x = dq_time[(dq_time >= time_min) & (dq_time <= time_max)]
-
-        y = t2[(dq_time >= time_min) & (dq_time <= time_max)]
-
-        if len(x) <= 1 or len(y) <= 1:
-            return
-
-        coeff = np.polyfit(x, y, 1)
-
-        Integral = np.trapz(dq)
-        DQ_norm = dq/Integral
-
-        self.ui.table_DQ.setColumnCount(5)
-        self.ui.table_DQ.setColumnWidth(4,70)
-        self.ui.table_DQ.setHorizontalHeaderItem(4, QTableWidgetItem("T₂* lin"))
-
-        self.ui.table_DQ.setColumnCount(6)
-        self.ui.table_DQ.setColumnWidth(5,70)
-        self.ui.table_DQ.setHorizontalHeaderItem(5, QTableWidgetItem("DQ Norm"))
-
-        for row in range(self.ui.table_DQ.rowCount()):
-            T2_lin = coeff[0] * dq_time[row] + coeff[1]
-            T2_lin = round(T2_lin, 4)
-            item = QTableWidgetItem(str(T2_lin))
-            self.ui.table_DQ.setItem(row, 4, item)
-            item2 = QTableWidgetItem(str(round(DQ_norm[row], 4)))
-            self.ui.table_DQ.setItem(row, 5, item2)
-
-
-        # Draw line
-        self.graph_line = self.ui.DQ_Widget_1
-
-        if coeff is not None:
-            # Generate x values for the line
-            x_line = np.arange(0, 105.1, 0.1)
-
-            # Calculate y values using the coefficients
-            y_line = np.polyval(coeff, x_line)
-
-            # Plot the graph and the line
-            self.dq_t2_graph()
-            self.graph_line.plot(x_line, y_line, pen='r')
-            self.t2_dq_graph()
-
-    def t2_dq_graph(self):
-        x = self.read_column_values(self.ui.table_DQ, 4)
-        y= self.read_column_values(self.ui.table_DQ, 5)
-
-        graph_DQ_distr = self.ui.DQ_Widget_2
-        button = self.ui.radioButton_Log
-        if button.isChecked():
-            new_x = np.log10(x)
-            graph_DQ_distr.getAxis('bottom').setLabel("log(T₂*)")
-        else:
-            new_x = x
-            graph_DQ_distr.getAxis('bottom').setLabel("T₂*")
-
-        graph_DQ_distr.clear()
-        graph_DQ_distr.plot(new_x, y, pen=None, symbol='o', symbolPen=None, symbolBrush=(255, 0, 0, 255), symbolSize=10)
-
-    def plot_fit(self):
-        _x = self.read_column_values(self.ui.table_DQ, 4)
-        y = self.read_column_values(self.ui.table_DQ, 5)
-
-        button = self.ui.radioButton_Log
-        if button.isChecked():
-            x = np.log10(_x)
-            p = [1, 1, 1, 0]
-            b=([0, 0, 0, 0, 0], [np.inf, np.inf, np.inf, 1, np.inf])
-            self.ui.DQ_Widget_2.getAxis('bottom').setLabel("log(T₂*)")
-        else:
-            x = _x
-            p = [1, 10, 10, 0]
-            b=([0, 0, 0, 0, 0], [ np.inf, np.inf, np.inf, 1, np.inf])
-            self.ui.DQ_Widget_2.getAxis('bottom').setLabel("T₂*")
-
-        text = self.ui.comboBox_FunctionDQ.currentText()
-
-        try:
-            x_fit = np.arange(0, np.max(x) + 0.001, 0.01)
-        except:
-            x_fit = np.arange(0, 100 + 0.001, 0.01)
-
-        b1=([0, 0, 0, -10], [np.inf, np.inf, np.inf, np.inf])
-
-        if text == 'Gauss':
-            params, _ = curve_fit(Cal.gaussian, x, y, p0=p, bounds=b1)
-            y_fit = Cal.gaussian(x_fit, *params)
-            y_r2 = Cal.gaussian(x, *params)
-            cen = params[1]
-            fwhm = params[2]
-            w = 0
-            button.setEnabled(True)
-        elif text == 'Lorenz':
-            params, _ = curve_fit(Cal.lorenz, x, y, p0=p, bounds=b1)
-            y_fit = Cal.lorenz(x_fit, *params)
-            y_r2 = Cal.lorenz(x, *params)
-            cen = params[1]
-            fwhm = params[2]
-            w = 1
-            button.setEnabled(True)
-        elif text == 'Pseudo Voigt':
-            params, _ = curve_fit(Cal.voigt, x, y,  bounds = b)
-            y_fit = Cal.voigt(x_fit, *params)
-            y_r2 = Cal.voigt(x, *params)
-            cen = params[1]
-            fwhm = params[2]
-            w = params[3]
-            button.setEnabled(True)
-        else:
-            button.setEnabled(False)
-            return
-
-        #R2
-        R = Cal.calculate_r_squared(y, y_r2)
-        # Plot the line
-        self.t2_dq_graph()
-        self.ui.DQ_Widget_2.plot(x_fit, y_fit, pen='r')
-
-        # Display R2, Xo and FWHM
-        self.ui.textEdit_4.setText(f"R\u00B2: {round(R, 4)} \nX\u2080: {round(cen, 4)} \nFWHM: {round(fwhm, 4)} \nFraction (Lorenz): {round(w,2)}")
-
-    # DQ Ref section
-    def dq_mq_analysis(self):
-
-        table = self.ui.table_DQMQ
-        table.clear()
-
-        try:
-            Time, DQ, Ref = self.plot_original()
-        except Exception as e:
-            QMessageBox.warning(self, "Corrupt File", f"Couldn't read the file beacuse {e}", QMessageBox.Ok)
-            self.clear_list()
-            return
-        num_rows  = len(Time)
-        table.setRowCount(num_rows)
-
-        for row in range(num_rows):
-            table.setItem(row, 0, QTableWidgetItem(str(Time[row])))
-            table.setItem(row, 1, QTableWidgetItem(str(DQ[row])))
-            table.setItem(row, 2, QTableWidgetItem(str(Ref[row])))
-
-        table.resizeColumnsToContents() # TODO ADD THIS EVERYWHERE!!!!
-        table.setHorizontalHeaderLabels(['Time','DQ','Ref','nDQ']) # I don't know why i need this, but otherwise the columns get 1234 headres.
-        self.ui.pushButton_DQMQ_1.setEnabled(True)
-        self.ui.pushButton_DQMQ_2.setEnabled(False)
-        self.ui.pushButton_DQMQ_3.setEnabled(False)
-        self.ui.pushButton_DQMQ_4.setEnabled(True)
-
-    def plot_original(self):
-        file_path = self.selected_DQMQfile[0]
-
-        figure = self.ui.DQMQ_Widget
-        figure.clear()
-        legend = figure.addLegend()
-        legend.clear()
-        legend = figure.addLegend()
-
-        try:
-            Time, DQ, Ref = Cal.read_data(file_path, 1)
-        except:
-            Time, DQ, Ref = Cal.read_data(file_path, 0)
-
-        time_shift = int(self.ui.DQMQtime_shift.value())
-        Time = Time + time_shift
-
-        figure.plot(Time, DQ, pen=mkPen('r', width=3), name = 'DQ')
-        figure.plot(Time, Ref, pen=mkPen('b', width=3), name = 'Ref')
-
-        return Time, DQ, Ref
-
-    def plot_norm(self):
-        file_path = self.selected_DQMQfile[0]
-        figure = self.ui.DQMQ_Widget
-        figure.clear()
-        legend = figure.addLegend()
-        legend.clear()
-        legend = figure.addLegend()
-        noise_level = self.ui.noise.value()
-        time_shift = int(self.ui.DQMQtime_shift.value())
-
-        Time, DQ_norm, Ref_norm, _, _, _, _, _, _, _ = Cal.dqmq(file_path, 40, 100, 1, noise_level, time_shift)
-
-        figure.plot(Time, DQ_norm, pen=mkPen('r', width=3), name = 'DQ')
-        figure.plot(Time, Ref_norm, pen=mkPen('b', width=3), name = 'Ref')
-
-        self.ui.pushButton_DQMQ_2.setEnabled(True)
-        self.ui.pushButton_DQMQ_3.setEnabled(True)
-        self.ui.dq_min_3.setEnabled(True)
-        self.ui.dq_max_3.setEnabled(True)
-        self.ui.power.setEnabled(True)
-
-    def plot_diff(self):
-        file_path = self.selected_DQMQfile[0]
-        fit_from = self.ui.dq_min_3.value()
-        fit_to = self.ui.dq_max_3.value()
-        p = self.ui.power.value()
-        noise_level = self.ui.noise.value()
-
-        figure = self.ui.DQMQ_Widget
-        figure.clear()
-        legend = figure.addLegend()
-        legend.clear()
-        legend = figure.addLegend()
-        time_shift = int(self.ui.DQMQtime_shift.value())
-
-        Time, _, _, Diff, DQ_norm, Ref_norm, _, _, fitted_curve, _ = Cal.dqmq(file_path, fit_from, fit_to, p, noise_level, time_shift)
-
-        figure.plot(Time, DQ_norm, pen=mkPen('r', width=2), name = 'DQ')
-        figure.plot(Time, Ref_norm, pen=mkPen('b', width=2), name = 'Ref')
-        figure.plot(Time, Diff, pen=mkPen('k', width=3), name = 'Diff')
-        figure.plot(Time, fitted_curve, pen=mkPen('m', width=3), name = 'fitting')
-
-        self.ui.pushButton_DQMQ_2.setEnabled(True)
-        self.ui.pushButton_DQMQ_3.setEnabled(True)
-
-    def plot_nDQ(self):
-        file_path = self.selected_DQMQfile[0]
-        fit_from = self.ui.dq_min_3.value()
-        fit_to = self.ui.dq_max_3.value()
-        p = self.ui.power.value()
-        table = self.ui.table_DQMQ
-
-        figure = self.ui.DQMQ_Widget
-        figure.clear()
-        legend = figure.addLegend()
-        legend.clear()
-        legend = figure.addLegend()
-        noise_level = self.ui.noise.value()
-        time_shift = int(self.ui.DQMQtime_shift.value())
-        smoothing = [self.ui.DQMQSmooth_from.value(), self.ui.DQMQSmooth_to.value(), int(self.ui.DQMQSmooth_window.value())]
-
-        Time, _, _, _, DQ_normal, Ref_normal, Time0, nDQ, _ , MQ_normal= Cal.dqmq(file_path, fit_from, fit_to, p, noise_level, time_shift, smoothing)
-
-        hline = InfiniteLine(pos=0.5, angle=0, pen=mkPen(color=(200, 200, 255), width=2, style=Qt.DashLine))
-        figure.addItem(hline)
-
-        figure.plot(Time, DQ_normal, pen=mkPen('r', width=3), name = 'DQ')
-        figure.plot(Time, Ref_normal, pen=mkPen('b', width=3), name = 'Ref')
-        figure.plot(Time, MQ_normal, pen=mkPen('m', width=3), name = 'MQ')
-        figure.plot(Time0, nDQ, pen=mkPen('k', width=3), symbol='o', symbolPen='k', symbolSize=10, name='nDQ')
-
-
-        num_rows  = len(Time)
-        for row in range(num_rows):
-            table.setItem(row, 3, QTableWidgetItem(str(round(nDQ[row+1],4))))
-        table.resizeColumnsToContents()
-
-    def plot_nDQ_on_Load(self):
-        table = self.ui.table_DQMQ
-        table.resizeColumnsToContents()
-        Time        = []
-        DQ_normal   = []
-        Ref_normal   = []
-        Time0       = []
-        nDQ         = []
-
-        row_count = table.rowCount()
-        for row in range(row_count):
-            Time.append(float(table.item(row, 0).text()))
-            DQ_normal.append(float(table.item(row, 1).text()))
-            Ref_normal.append(float(table.item(row, 2).text()))
-            nDQ.append(float(table.item(row, 3).text()))
-
-        Time = np.array(Time)
-        DQ_normal = np.array(DQ_normal)
-        Ref_normal = np.array(Ref_normal)
-        DQ_normal, Ref_normal, _ = Cal.normalize_mq(DQ_normal, Ref_normal, 'plus')
-        nDQ = np.array(nDQ)
-        nDQ = np.insert(nDQ, 0, 0)
-        Time0 = np.insert(Time, 0, 0)
-
-        figure = self.ui.DQMQ_Widget
-        figure.clear()
-        legend = figure.addLegend()
-        legend.clear()
-        legend = figure.addLegend()
-        figure.plot(Time, DQ_normal, pen=mkPen('r', width=3), name = 'DQ')
-        figure.plot(Time, Ref_normal, pen=mkPen('b', width=3), name = 'Ref')
-        figure.plot(Time0, nDQ, pen=mkPen('k', width=3), symbol='o', symbolPen='k', symbolSize=10, name='nDQ')
-
-    # Relaxation time section
-    # A good example ofr bad architecture with no thoughts of scaling whatsoever.
-    # Will i learn?
-    # Lol, no
-    def update_T12_table(self):
-        def clean_line(line):
-            while '\t\t' in line:
-                line = line.replace('\t\t', '\t')
-            return line.strip()
-
-        def create_dictionary(dictionary, file, addition, x_axis, Time, Signal):
-            dictionary[file + addition]["X Axis"].append(x_axis)
-            dictionary[file + addition]["Time"].extend(Time)
-            dictionary[file + addition]["Signal"].extend(Signal)
-            return dictionary
-
-        selected_files = self.selected_T1files
-        table = self.ui.table_T1
-        combobox = self.ui.T1T2_ChooseFileComboBox
-        # pattern = r'(T1|T2)_(\s?-?\d+)(_.*)?\.dat'
-        pattern = r'(T1|T2)_(\s?-?\d+(\.\d+)?)((_.*)?\.(dat|txt))'
-        dictionary = self.tau_dictionary
-
-        try:
-            if os.path.splitext(selected_files[0])[1]  == '.sef': # Read data aqcuired from Evaluation of FFC machine version1
-                if os.path.splitext(selected_files[1])[1] != '.sef':
-                    QMessageBox.warning(self, "Error", f"Load two files: Magnetization and Profile in .sef format.", QMessageBox.Ok)
-                    for file_to_delete in selected_files:
-                        if file_to_delete == file:
-                            selected_files.remove(file)
-                try:
-                    if os.stat(selected_files[0]).st_size > os.stat(selected_files[1]).st_size:
-                        filetoreadzones  = selected_files[1]
-                        filetoreaddata   = selected_files[0]
-                    else:
-                        filetoreadzones = selected_files[0]
-                        filetoreaddata  = selected_files[1]
-                    dictionary = self.process_files(filetoreadzones, filetoreaddata)
-
-                    # Fill the table
-                    table.setRowCount(len(dictionary))
-
-
-                    for row, key in zip(range(table.rowCount()), dictionary):
-                        x_axis = dictionary[key]["X Axis"]
-                        Temp = QTableWidgetItem(x_axis)
-                        Folder  = QTableWidgetItem(filetoreaddata)
-                        Filename   = QTableWidgetItem(os.path.basename(filetoreaddata))
-                        table.setItem(row, 0, Folder)
-                        table.setItem(row, 1, Filename)
-
-
-                        table.setItem(row, 2, Temp)
-                        combobox.addItem(f"{x_axis}")
-
-                    self.tau_dictionary = dictionary
-                    self.state_bad_code = True
-                except:
-                    QMessageBox.warning(self, "Error", f"Something went wrong.\nLoad two files: Magnetization and Profile.", QMessageBox.Ok)
-                    for file_to_delete in selected_files:
-                        if file_to_delete == file:
-                            selected_files.remove(file)
-
-            elif os.path.splitext(selected_files[0])[1] == '.csv': # Reading T1 recorded transformed from relaxyzer by prerecorded FIDs - this is a VERY bad way to solve things...
-                self.state_bad_code = False
-                table.setRowCount(len(selected_files))
-                x_axis = []
-                csv_pattern =  r'_(\-?\d+)(?=\.csv$)'
-                for row, file in zip(range(table.rowCount()), selected_files):
-                    current_file = os.path.basename(file)
-                    Time = []
-                    Signal = []
-
-                    try:
-                        x_axis = re.search(csv_pattern, current_file).group(1)
-                    except:
-                        x_axis = row
-
-                    dictionary[file] = {"X Axis": [], "Time": [], "Signal": []}
-                    data = []
-                    with open(file) as f:
-                        for line in f:
-                            parts = line.strip().split(",")
-
-                            time_value = float(parts[0])
-                            signal_value = float(parts[1])
-                            Time.append(time_value)
-                            Signal.append(signal_value)
-
-                    # fill dictionary
-                    dictionary[file]["X Axis"].append(x_axis)
-                    dictionary[file]["Time"].extend(Time)
-                    dictionary[file]["Signal"].extend(Signal)
-
-                    # fill table
-                    Folder = QTableWidgetItem(file)
-                    Filename = QTableWidgetItem(current_file)
-                    Temp = QTableWidgetItem(str(x_axis))
-                    table.setItem(row, 0, Folder)
-                    table.setItem(row, 1, Filename)
-                    table.setItem(row, 2, Temp)
-
-                    combobox.addItem(f"{current_file}")
-
-            elif os.path.splitext(selected_files[0])[1] == '.txt': # Reading T1 recorded at different time regions - this is a VERY bad way to solve things...
-                self.state_bad_code = False
-                table.setRowCount(len(selected_files*4))
-                x_axis = []
-
-                pattern_all = r'T1_.*_(\s?-?\d+).txt'
-
-                for file in selected_files:
-
-                    try:
-                        x_axis = re.search(pattern_all, os.path.basename(file)).group(1)
-                    except:
-                        x_axis = 'Variable'
-
-                    Time = []
-                    Signal_all = []
-                    Signal_short = []
-                    Signal_med = []
-                    Signal_long =[]
-
-                    dictionary[file + '_all'] = {"X Axis": [], "Time": [], "Signal": []}
-                    dictionary[file + '_short'] = {"X Axis": [], "Time": [], "Signal": []}
-                    dictionary[file + '_medium'] = {"X Axis": [], "Time": [], "Signal": []}
-                    dictionary[file + '_long'] = {"X Axis": [], "Time": [], "Signal": []}
-
-                    with open(file, "r") as data:
-                        #lines = [line.replace('\t\t\t', '').rstrip('\n') for line in data if not (line.rstrip('\n').endswith('\t\t\t\t'))]
-                        lines = [clean_line(line.rstrip('\n')) for line in data if line.strip()]
-                        for line in lines[1:]:  # Skip the first line !!!
-                            parts = line.split('\t')
-                            Time.append(float(parts[0]))
-                            Signal_all.append(float(parts[1]))
-                            Signal_short.append(float(parts[2]))
-                            Signal_med.append(float(parts[3]))
-                            Signal_long.append(float(parts[4]))
-
-                        dictionary = create_dictionary(dictionary, file, '_all', x_axis, Time, Signal_all)
-                        dictionary = create_dictionary(dictionary, file, '_short', x_axis, Time, Signal_short)
-                        dictionary = create_dictionary(dictionary, file, '_medium', x_axis, Time, Signal_med)
-                        dictionary = create_dictionary(dictionary, file, '_long', x_axis, Time, Signal_long)
-
-                for row, entry in zip(range(table.rowCount()), dictionary):
-                    Folder = QTableWidgetItem(entry)
-                    current_file = os.path.basename(entry)
-                    Filename = QTableWidgetItem(current_file)
-                    x_axis = dictionary[entry]["X Axis"][0]
-                    try:
-                        Temp = QTableWidgetItem(x_axis)
-                    except:
-                        x_axis = str(row)
-                        Temp = QTableWidgetItem(x_axis)
-                    table.setItem(row, 0, Folder)
-                    table.setItem(row, 1, Filename)
-                    table.setItem(row, 2, Temp)
-                    combobox.addItem(f"{current_file}")
-            else: # Normal reading
-                self.state_bad_code = False
-                table.setRowCount(len(selected_files))
-                x_axis = []
-                for row, file in zip(range(table.rowCount()), selected_files):
-                    dictionary[file] = {"X Axis": [], "Time": [], "Signal": []}
-
-                    Time = []
-                    Signal = []
-                    Folder = QTableWidgetItem(file)
-
-                    current_file = os.path.basename(file)
-
-                    try:
-                        x_axis = re.search(pattern,current_file).group(2)
-                    except:
-                        x_axis = row
-                    try:
-                    # Read files as I create them from excel in spintrack
-                        with open(file, "r") as data:
-                            #lines = [line.replace('\t\t\t', '').rstrip('\n') for line in data if not (line.rstrip('\n').endswith('\t\t\t\t'))]
-                            lines = [clean_line(line.rstrip('\n')) for line in data if line.strip()]
-                        for line in lines[1:]:  # Skip the first line !!!
-                            parts = line.split('\t')
-                            time_value = float(parts[0])
-                            signal_value = float(parts[1])
-                            Time.append(time_value)
-                            Signal.append(signal_value)
-
-                        combobox.addItem(f"{current_file}")
-                    except:
-                        try:
-                            # read files regularly
-                            data = np.loadtxt(file)
-                            Time, Signal = data[:, 0], data[:, 1]
-
-                            combobox.addItem(f"{current_file}")
-                        except FileNotFoundError:
-                            QMessageBox.warning(self, "File Not Found", f"The file {file} was not found. Only table data is available.", QMessageBox.Ok)
-                            return
-                        except Exception as e:
-                            QMessageBox.warning(self, "Invalid Data", f"I couldn't read {current_file} because {e} Removing file from the table and file list.", QMessageBox.Ok)
-                            for file_to_delete in selected_files:
-                                if file_to_delete == file:
-                                    selected_files.remove(file)
-                            return
-
-                    Filename = QTableWidgetItem(current_file)
-                    Temp = QTableWidgetItem(x_axis)
-                    table.setItem(row, 0, Folder)
-                    table.setItem(row, 1, Filename)
-                    table.setItem(row, 2, Temp)
-                    dictionary[file]["X Axis"].append(x_axis)
-                    dictionary[file]["Time"].extend(Time)
-                    dictionary[file]["Signal"].extend(Signal)
-
-        except:
-            QMessageBox.warning(self, "Error", f"Something went wrong. Try again.", QMessageBox.Ok)
-            self.clear_list()
-
-        self.ui.btn_Plot1.setEnabled(True)
-        combobox.setCurrentIndex(-1)
-
-    def process_files(self, file1, file2):
-        # Step 1: Parse the first file to map Zones to Frequencies
-        zone_to_frequency = {}
-        with open(file1, 'r') as f1:
-            for line in islice(f1, 4, None):
-                parts = line.split()
-                frequency = parts[0]
-                zone = parts[-2]
-                zone_to_frequency[zone] = frequency
-
-        # Step 2: Parse the second file to extract Time and Signal data
-        dictionary = {}
-        current_zone = None
-        with open(file2, 'r') as f2:
-            for line in f2:
-                line = line.strip()
-
-                # Detect new Zone block
-                if line.startswith("Zone"):
-                    current_zone = line.split()[1]
-                    continue
-
-                # Skip header and empty lines
-                if not line or line.startswith("TAU") or line.startswith("---"):
-                    continue
-
-                # Extract Time and Signal data
-                if current_zone in zone_to_frequency:
-                    try:
-                        parts = line.split()
-                        time = float(parts[0])  # Time column
-                        signal = float(parts[1])  # Signal column
-                        frequency = zone_to_frequency[current_zone]
-
-                        # Initialize dictionary entry if not exists
-                        name = file2 + ' at freq:' + str(frequency)
-                        if name not in dictionary:
-                            dictionary[name] = {"X Axis": frequency, "Time": [], "Signal": []}
-
-                        # Append data
-                        dictionary[name]["Time"].append(time)
-                        dictionary[name]["Signal"].append(signal)
-                    except (ValueError, IndexError):
-                        continue
-
-        return dictionary
-
-    def change_exponential_order(self):
-        self.ui.DSB_ExpFitting1.setValue(100)
-        self.ui.DSB_ExpFitting2.setValue(1000)
-        self.ui.DSB_ExpFitting3.setValue(10000)
-
-        if self.ui.T1T2_FitWith1ExpButton.isChecked():
-            self.ui.DSB_ExpFitting1.setEnabled(True)
-            self.ui.DSB_ExpFitting2.setEnabled(False)
-            self.ui.DSB_ExpFitting3.setEnabled(False)
-
-        elif self.ui.T1T2_FitWith2ExpButton.isChecked():
-            self.ui.DSB_ExpFitting1.setEnabled(True)
-            self.ui.DSB_ExpFitting2.setEnabled(True)
-            self.ui.DSB_ExpFitting3.setEnabled(False)
-        else:
-            self.ui.DSB_ExpFitting1.setEnabled(True)
-            self.ui.DSB_ExpFitting2.setEnabled(True)
-            self.ui.DSB_ExpFitting3.setEnabled(True)
-
-        self.calculate_relaxation_time()
-
-    def calculate_relaxation_time(self):
-        table = self.ui.table_T1
-        figure = self.ui.T1_Widget_1
-        selected_file_idx = self.ui.T1T2_ChooseFileComboBox.currentIndex()
-        dictionary = self.tau_dictionary
-        starting_point = int(self.ui.T1T2_fit_from.value())
-        ending_point = -(int(self.ui.T1T2_fit_to.value()))
-        if ending_point == 0:
-            ending_point = None
-
-        if self.ui.radioButton_16.isChecked():
-        # milisec units
-            denominator = 1
-        else:
-        # microsec units
-            denominator = 1000
-
-        if selected_file_idx == -1:
-            return
-
-        if self.state_bad_code == True:
-            value_from_row = table.item(selected_file_idx, 0).text() + ' at freq:' + table.item(selected_file_idx, 2).text()
-            denominator = 0.001
-        else:
-            value_from_row = table.item(selected_file_idx, 0).text()
-        Time_original = np.array(dictionary[value_from_row]['Time'])/denominator
-        Signal_original = np.array(dictionary[value_from_row]['Signal'])
-
-        Time = Time_original[starting_point:ending_point]
-        Signal = Signal_original[starting_point:ending_point]
-
-        try:
-
-            t1 = int(self.ui.DSB_ExpFitting1.value())
-            t2 = int(self.ui.DSB_ExpFitting2.value())
-            t3 = int(self.ui.DSB_ExpFitting3.value())
-
-            if self.ui.T1T2_FitWith1ExpButton.isChecked():
-                order = 1
-                initial_parameters = [Signal[0], t1, 1]
-            elif self.ui.T1T2_FitWith2ExpButton.isChecked():
-                order = 2
-                initial_parameters = [Signal[0], t1, Signal[0], t2, 1]
-            else:
-                order = 3
-                initial_parameters = [Signal[0], t1, Signal[0], t2, Signal[0], t3, 1]
-
-
-            Time_fit, fitted_curve, tau1, tau2, tau3, R2, A1, A2, A3 = Cal.fit_exponent(Time, Signal, order, initial_parameters)
-            self.ui.textEdit_error.setText(f"R² {R2}")
-
-        except:
-            QMessageBox.warning(self, "No covariance", f"I am sorry, I couldn't fit with {order} exponents. Decrease the order of fitting and try again.", QMessageBox.Ok)
-            return
-
-        # set taus into boxes
-        self.ui.DSB_ExpFitting1.setValue(tau1)
-        self.ui.DSB_ExpFitting2.setValue(tau2)
-        self.ui.DSB_ExpFitting3.setValue(tau3)
-
-        item1 = QTableWidgetItem(str(tau1))
-        item2 = QTableWidgetItem(str(tau2))
-        item3 = QTableWidgetItem(str(tau3))
-        item11 = QTableWidgetItem(str(A1))
-        item22 = QTableWidgetItem(str(A2))
-        item33 = QTableWidgetItem(str(A3))
-
-        table.setItem(selected_file_idx,3,item1)
-        table.setItem(selected_file_idx,5,item2)
-        table.setItem(selected_file_idx,7,item3)
-        table.setItem(selected_file_idx,4,item11)
-        table.setItem(selected_file_idx,6,item22)
-        table.setItem(selected_file_idx,8,item33)
-
-        figure.clear()
-        figure.plot(Time_original, Signal_original, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10)
-        figure.plot(Time_fit, fitted_curve, pen='b')
-
-        dictionary[value_from_row]['T1 1'] = tau1
-        dictionary[value_from_row]['T1 2'] = tau2
-        dictionary[value_from_row]['T1 3'] = tau3
-        self.ui.btn_Plot1.setEnabled(True)
-
-    def plot_relaxation_time(self):
-
-        table = self.ui.table_T1
-        graph = self.ui.T1_Widget_2
-
-        if self.ui.T1T2_1expPlotButton.isChecked():
-            column = 3
-        elif self.ui.T1T2_2expPlotButton.isChecked():
-            column = 5
-        elif self.ui.T1T2_3expPlotButton.isChecked():
-            column = 7
-
-        graph.clear()
-        if table.rowCount() < 1:
-            return
-
-        x_axis = []
-        relaxation_time =[]
-        number = 1
-        for row in range(table.rowCount()):
-            try:
-                C = float(table.item(row, 2).text())
-                x_axis.append(C)
-            except:
-                x_axis.append(number)
-
-            try:
-                T = float(table.item(row, column).text())
-                relaxation_time.append(T)
-            except:
-                relaxation_time.append(0)
-            number = number + 1
-
-        graph.plot(x_axis, relaxation_time, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10)
-
-        if self.group_data_T1T2:
-            for i, (group_number, group_rows) in enumerate(self.group_data_T1T2.items()):
-                group_x = []
-                group_y = []
-
-                for row_data in group_rows:
-                    try:
-                        x_val = float(row_data[2])
-                        y_val = float(row_data[column])
-                        group_x.append(x_val)
-                        group_y.append(y_val)
-                    except (ValueError, IndexError):
-                        continue
-
-                sorted_points = sorted(zip(group_x, group_y), key=lambda p: p[0])
-                if len(sorted_points) > 1:
-                    xs, ys = zip(*sorted_points)
-
-                    color = self.tab10_colors[i % len(self.tab10_colors)]
-
-                    graph.plot(
-                        xs, ys,
-                        pen={'color': color, 'width': 2},
-                        symbol='o',
-                        symbolBrush=color,
-                        symbolPen=None,
-                        symbolSize=8
-                    )
-
-    # Working with tables
-    def update_DQ_comparison(self):
-        table = self.ui.table_DQ_2
-        table.setRowCount(len(self.selected_DQfiles))
-
-        for row, parent_folder in enumerate(self.selected_DQfiles, start=0):
-            foldername = os.path.dirname(parent_folder)
-            filename = os.path.basename(parent_folder)
-
-            try:
-                data = np.loadtxt(parent_folder, delimiter=',')
-                if data.shape[1] < 3:
-                    QMessageBox.warning(self, "Invalid Data", f"The file {foldername} does not have at least 3 columns and will be removed from the table and file list.", QMessageBox.Ok)
-                    table.removeRow(row)
-                    del self.selected_DQfiles[row]
-
-            except Exception as e: 
-                QMessageBox.warning(self, "Invalid Data", f"The file {foldername} {e} Removed from the table and file list.", QMessageBox.Ok)
-                table.removeRow(row)
-                del self.selected_DQfiles[row]
-
-            item = QTableWidgetItem(filename)
-            item_name = QTableWidgetItem()
-
-            pattern = r'Table_DQ_(-?[0-9]+).*.csv'
-            try:
-                item_xaxis = float(re.search(pattern, filename).group(1))
-                item_name.setData(Qt.EditRole, item_xaxis)
-            except:
-                item_name.setData(Qt.EditRole, float(row+1))
-
-            table.setItem(row, 0, item)
-            table.setItem(row, 1, item_name)
-
-        table.resizeColumnsToContents()
-
-        self.launch()
-
-    def launch(self):
-        try:
-            self.dq_t2 = {}
-            for row, parent_folder in enumerate(self.selected_DQfiles, start=0):
-                # Read data from file
-                data = np.loadtxt(parent_folder, delimiter=',')
-
-                # Read the DQ filtering time, DQ amlitude and corresponding T2*
-                dq_t2 = data[:, [4, 5]]
-                self.dq_t2[row] = dq_t2
-            self.update_DQ_comparison_plot()
-        except Exception as e:
-            QMessageBox.warning(self, "Corrupted file", f"Couldn't analyse the {os.path.dirname(parent_folder)} because {e}", QMessageBox.Ok)
-
-    def update_DQ_comparison_plot(self):
-        cmap = pg.ColorMap([0, len(self.dq_t2)], [pg.mkColor('b'), pg.mkColor('r')])  # Blue to red
-
-        self.dq_comparison_distribution = {'File name': [], 
-                'X axis': [], 'Center': [], 'FWHM': [], 'Lorentz ratio': [], 
-                'Fitting type': [], 'T2 limit': []}
-
-        legend = self.ui.DQ_Widget_4.addLegend(offset=(0,0))
-        legend_functionsCenters = self.ui.DQ_Widget_5.addLegend()
-        self.ui.DQ_Widget_5.clear()
-        self.ui.DQ_Widget_4.clear()
-        self.ui.DQ_Widget_polyFit.clear()
-
-        if legend is not None:
-            legend.clear()
-            legend.setPen((0, 0, 0)) 
-
-        if legend_functionsCenters is not None:
-            legend_functionsCenters.clear()
-            legend_functionsCenters.setPen((0, 0, 0)) 
-
-
-        legend.anchor(itemPos=(1, 0), parentPos=(1, 0))
-
-        # This is a mess :(
-        center_g = []
-        center_l = []
-        center_v = []
-        center_d = []
-
-        bold_g = []
-        bold_l = []
-        bold_v = []
-
-        comparison_par = []
-
-        for row, (key, data) in zip(range(self.ui.table_DQ_2.rowCount()), self.dq_t2.items()):
-            file_name_item = self.ui.table_DQ_2.item(row, 1)
-            file_item = self.ui.table_DQ_2.item(row, 0)
-            if file_name_item is not None:
-                file_name = file_name_item.text()
-                file = file_item.text()
-                if file_name != 'hide': #TODO OHMYGOD SERIOUSLY?????????????
-                    try:
-                        _comp_par = float(file_name)
-                    except:
-                        _comp_par = 0
-                        self.ui.table_DQ_2.setItem(row, 1, QTableWidgetItem('0'))
-                    comparison_par.append(_comp_par)
-                else:
-                    continue
-
-            # Initial arrays
-            t2_lin = data[:,0] #T2*
-            dq_norm = data[:,1]
-
-            # Initial fitting parameters with statistical functions
-            p = [1, 5, 5, 0]
-            b=([0, 0, 0, 0, 0], [ np.inf, np.inf, np.inf, 1, np.inf]) # Voigt
-            b1=([0, 0, 0, -10], [np.inf, np.inf, np.inf, np.inf]) # Gauss and Lorenz
-
-            # create an array of T2* for plotting fitted function
-            t2_fit = np.arange(0, np.max(t2_lin) + 0.001, 0.01)
-
-            # Fit with 3 different functions and get centers
-            # if text == 'Gauss':
-            params, _ = curve_fit(Cal.gaussian, t2_lin, dq_norm, p0=p, bounds=b1)
-            cen_g = params[1]
-            center_g.append(cen_g)
-            fwhm_g = params[2]
-            bold_g.append(fwhm_g)
-
-            # elif text == 'Lorenz':
-            params, _ = curve_fit(Cal.lorenz, t2_lin, dq_norm, p0=p, bounds=b1)
-            cen_l = params[1]
-            center_l.append(cen_l)
-            fwhm_l = params[2]
-            bold_l.append(fwhm_l)
-
-            # elif text == 'Pseudo Voigt':
-            params, _ = curve_fit(Cal.voigt, t2_lin, dq_norm,  bounds = b)
-            cen_v = params[1]
-            center_v.append(cen_v)
-            fwhm_v = params[2]
-            bold_v.append(fwhm_v)
-
-            y_fit = Cal.voigt(t2_fit, *params)
-
-            # Fitting with polynomial and derivative search:
-            t2_detivative_plot, nDQ_derivative_plot, center_derivative = Cal.derivative_peak_find(t2_lin, dq_norm)
-            center_d.append(center_derivative)
-
-            # Draw a graph T2* versus nDQ data and fitted functions
-            color = tuple(cmap.map(key))
-            self.ui.DQ_Widget_4.plot(t2_lin, dq_norm, pen=None, symbolPen=None, symbol='o', symbolBrush=color, symbolSize=10, name=file_name)
-            self.ui.DQ_Widget_4.plot(t2_fit, y_fit, pen=color)
-
-            self.ui.DQ_Widget_polyFit.plot(t2_lin, dq_norm, pen=None, symbolPen=None, symbol='o', symbolBrush=color, symbolSize=10)
-            self.ui.DQ_Widget_polyFit.plot(t2_detivative_plot, nDQ_derivative_plot, pen=color)
-
-            # Add centers values to the table:
-            def set_numeric_item(table, row, col, value):
-                item = QTableWidgetItem()
-                item.setData(Qt.EditRole, round(float(value), 2))
-                table.setItem(row, col, item)
-
-            # Add centers values to the table
-            set_numeric_item(self.ui.table_DQ_2, row, 2, cen_g)
-            set_numeric_item(self.ui.table_DQ_2, row, 3, cen_l)
-            set_numeric_item(self.ui.table_DQ_2, row, 4, cen_v)
-            set_numeric_item(self.ui.table_DQ_2, row, 5, center_derivative)
-
-            # Add FWHM values to the table
-            set_numeric_item(self.ui.table_DQ_2, row, 6, fwhm_g)
-            set_numeric_item(self.ui.table_DQ_2, row, 7, fwhm_l)
-            set_numeric_item(self.ui.table_DQ_2, row, 8, fwhm_v)
-
-            #TODO: make disctionary self.dq_comparison_distribution['File name'].append(file) updates
-
-        self.ui.DQ_Widget_5.plot(comparison_par, center_g, pen='r', symbolPen=None, symbol='o', symbolBrush='r', name='Gaus')
-        self.ui.DQ_Widget_5.plot(comparison_par, center_l, pen='b', symbolPen=None, symbol='o', symbolBrush='b', name='Lorenz')
-        self.ui.DQ_Widget_5.plot(comparison_par, center_v, pen='k', symbolPen=None, symbol='o', symbolBrush='k', name='Voigt')
-        self.ui.DQ_Widget_5.plot(comparison_par, center_d, pen='g', symbolPen=None, symbol='o', symbolBrush='g', name='Derivative')
 
     def write_collective_dictionary(self, dictionary, save_path_name):
         # file = name of the file
@@ -1890,7 +725,7 @@ class MainWindow(QMainWindow):
         dialog.save_data_as_csv(self, table, files, default_name)
 
         if self.state_bad_code == True:
-            self.bad_code_makes_more_bad_code()
+            self.t1t2_controller.bad_code_makes_more_bad_code()
 
     def load_data(self):
         dlg = OpenFilesDialog(self)
@@ -1921,6 +756,7 @@ class MainWindow(QMainWindow):
         elif self.tab == 'DQ':
             table = self.ui.table_DQ
             self.selected_files_DQ_single = files
+            self.app_state.dq_files = files
         elif self.tab == 'DQ_Temp':
             table = self.ui.table_DQ_2
             self.selected_DQfiles = files
@@ -1930,6 +766,7 @@ class MainWindow(QMainWindow):
         elif self.tab == 'DQMQ':
             table = self.ui.table_DQMQ
             self.selected_DQMQfile = files
+            self.app_state.dqmq_files = files
         elif self.tab == 'GS':
             table = self.ui.table_GS
             self.selected_GSfiles = files
@@ -1947,11 +784,11 @@ class MainWindow(QMainWindow):
         if self.tab == 'SE':
             self.update_se_graphs()
         elif self.tab == 'DQ':
-            self.update_dq_graphs()
+            self.dq_controller.update_graphs()
         elif self.tab == 'DQ_Temp':
-            self.update_DQ_comparison()
+            self.dq_temp_controller.update_DQ_comparison()
         elif self.tab == 'T1T2':
-            self.update_T12_table()
+            self.t1t2_controller.update_T12_table()
         elif self.tab == 'DQMQ':
             self.ui.pushButton_DQMQ_1.setEnabled(True)
             self.ui.pushButton_DQMQ_2.setEnabled(True)
@@ -1960,10 +797,10 @@ class MainWindow(QMainWindow):
             self.ui.dq_min_3.setEnabled(True)
             self.ui.dq_max_3.setEnabled(True)
             self.ui.power.setEnabled(True)
-            self.plot_nDQ_on_Load()
+            self.dqmq_controller.plot_nDQ_on_Load()
 
         elif self.tab == 'GS':
-            self.update_GS_table()
+            self.gs_controller.update_GS_table()
 
     def save_figures(self, file_path, variable):
         parent_folder = os.path.dirname(file_path)
@@ -2039,280 +876,6 @@ class MainWindow(QMainWindow):
             else:
                 return False
 
-    # FFC analysis
-    def bad_code_makes_more_bad_code(self):
-        dictionary = self.tau_dictionary
-        dialog = SaveFilesDialog(self)
-        basename = os.path.basename(self.selected_T1files[0])
-
-        save = not all(data.get('T1 1', 0) == 0 for data in dictionary.values())
-        dialog.save_file_in_sef(self, dictionary, 'T1 1', 1, basename, save)
-
-        save = not all(data.get('T1 2', 0) ==0 for data in dictionary.values())
-        dialog.save_file_in_sef(self, dictionary, 'T1 2', 2, basename, save)
-
-        save = not all(data.get('T1 3', 0) == 0 for data in dictionary.values())
-        dialog.save_file_in_sef(self, dictionary, 'T1 3', 3, basename, save)
-
-    # GS Goldman Shen
-    def update_GS_table(self):
-        def clean_line(line):
-            while '\t\t' in line:
-                line = line.replace('\t\t', '\t')
-            return line.strip()
-
-        def create_dictionary(dictionary, file, addition, x_axis, sqrtTime, short, medium, long):
-            dictionary[file + addition]["X Axis"].append(x_axis)
-            dictionary[file + addition]["sqrtTime"].extend(sqrtTime)
-            dictionary[file + addition]["short"].extend(short)
-            dictionary[file + addition]["medium"].extend(medium)
-            dictionary[file + addition]["long"].extend(long)
-            return dictionary
-
-        selected_files = self.selected_GSfiles
-        table = self.ui.table_GS
-        combobox = self.ui.comboBox_7
-
-        pattern = r'_([0-9]+)\.dat$'
-        dictionary = self.GS_dictionary
-
-        try:
-            table.setRowCount(len(selected_files))
-            x_axis = []
-            for row, file in zip(range(table.rowCount()), selected_files):
-                dictionary[file] = {"X Axis": [], "sqrtTime": [], "short": [], "medium": [], "long": []}
-
-                sqrtTime = []
-                short = []
-                medium = []
-                long = []
-                Folder = QTableWidgetItem(file)
-
-                current_file = os.path.basename(file)
-
-                try:
-                    x_axis = re.search(pattern,current_file).group(1)
-                except:
-                    x_axis = row
-
-                try:
-                    with open(file, "r") as data:
-                        lines = [clean_line(line.rstrip('\n')) for line in data if line.strip()]
-                    for line in lines[1:]:  # Skip the first line !!!
-                        parts = line.split('\t')
-                        time_value = float(parts[0])
-                        signal_value1 = float(parts[4])
-                        signal_value2 = float(parts[5])
-                        signal_value3 = float(parts[6])
-
-                        sqrtTime.append(time_value)
-                        short.append(signal_value1)
-                        medium.append(signal_value2)
-                        long.append(signal_value3)
-
-                    combobox.addItem(f"{current_file}")
-                except Exception as e:
-                    QMessageBox.warning(self, "Invalid Data", f"I couldn't read {current_file} because {e} Removing file from the table and file list.", QMessageBox.Ok)
-                    for file_to_delete in selected_files:
-                        if file_to_delete == file:
-                            selected_files.remove(file)
-                    return
-
-                Filename = QTableWidgetItem(current_file)
-                XValue = QTableWidgetItem(x_axis)
-                table.setItem(row, 0, Folder)
-                table.setItem(row, 1, Filename)
-                table.setItem(row, 2, XValue)
-                dictionary[file]["X Axis"].append(x_axis)
-                dictionary[file]["sqrtTime"].extend(sqrtTime)
-                dictionary[file]["short"].extend(short)
-                dictionary[file]["medium"].append(medium)
-                dictionary[file]["long"].extend(long)
-
-        except Exception as e:
-            QMessageBox.warning(self, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
-            self.clear_list()
-
-    def calculate_sqrt_time(self):
-        selected_file_idx = self.ui.comboBox_7.currentIndex()
-        if selected_file_idx == -1:
-            return
-        table = self.ui.table_GS
-        figure = self.ui.GS_Widget_1
-
-        dictionary = self.GS_dictionary
-
-        value_from_row = table.item(selected_file_idx, 0).text()
-
-        if self.ui.checkBox_3.isChecked():
-        # transform to sqrt
-            Time_original = np.sqrt(np.array(dictionary[value_from_row]['sqrtTime']).flatten())
-        else: # time is already in sqrt
-            Time_original = np.array(dictionary[value_from_row]['sqrtTime']).flatten()
-
-        short_original = np.array(dictionary[value_from_row]['short']).flatten()
-        medium_original = np.array(dictionary[value_from_row]['medium']).flatten()
-        long_original = np.array(dictionary[value_from_row]['long']).flatten()
-
-        self.ui.GS_fit_from_1.setMinimum(Time_original[0])
-        self.ui.GS_fit_from_1.setMaximum(Time_original[-1])
-
-        self.ui.GS_fit_to_1.setMinimum(Time_original[15])
-        self.ui.GS_fit_to_1.setMaximum(Time_original[-1])
-
-        from_val = self.ui.GS_fit_from_1.value()
-        to_val = self.ui.GS_fit_to_1.value()
-
-        # Find the closest indices to the selected Time range
-        starting_point = (np.abs(Time_original - from_val)).argmin()
-        ending_point = (np.abs(Time_original - to_val)).argmin() + 1  # +1 to include the endpoint
-
-        Time = Time_original[starting_point:ending_point]
-        short = short_original[starting_point:ending_point]
-        medium = medium_original[starting_point:ending_point]
-        long = long_original[starting_point:ending_point]
-
-
-        if self.ui.radioButton_short.isChecked():
-            Signal = short
-            Signal_original = short_original
-        elif self.ui.radioButton_medium.isChecked():
-            Signal = medium
-            Signal_original = medium_original
-        elif self.ui.radioButton_long.isChecked():
-            Signal = long
-            Signal_original = long_original
-
-        beta    =   self.ui.GS_beta.value()
-        r2    =   self.ui.GS_r2.value()
-        M2    =   self.ui.GS_m2.value()
-        try:
-            Time_fit, fitted_curve, sqrtT, R2 = Cal.linear_fit_GS(Time, Signal)
-            d = Cal.calculate_domain_size(sqrtT, beta, r2, M2)
-
-            self.ui.textEdit_error_2.setText(f"R² {R2}")
-
-            item = QTableWidgetItem(str(sqrtT))
-
-            table.setItem(selected_file_idx,3,item)
-
-            item2 = QTableWidgetItem(str(d))
-
-            table.setItem(selected_file_idx,4,item2)
-
-            figure.clear()
-            figure.plot(Time_original, Signal_original, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10)
-            figure.plot(Time_fit, fitted_curve, pen='b')
-
-            dictionary[value_from_row]['sqrtT'] = sqrtT
-            dictionary[value_from_row]['d'] = d
-
-            self.ui.btn_Plot1.setEnabled(True)
-        except Exception as e:
-            figure.clear()
-            QMessageBox.warning(self, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
-
-    def plot_sqrt_time(self):
-
-        table = self.ui.table_GS
-        graph = self.ui.GS_Widget_2
-        column = 3 #time
-
-        graph.clear()
-        if table.rowCount() < 1:
-            return
-
-        x_axis = []
-        sqrtT =[]
-        number = 1
-        for row in range(table.rowCount()):
-            try:
-                C = float(table.item(row, 2).text())
-                x_axis.append(C)
-            except:
-                x_axis.append(number)
-
-            try:
-                T = float(table.item(row, column).text())
-                sqrtT.append(T)
-            except:
-                sqrtT.append(0)
-            number = number + 1
-
-        graph.plot(x_axis, sqrtT, pen=None, symbolPen=None, symbol='o', symbolBrush='r', symbolSize=10)
-
-        if self.group_data_SD:
-            for i, (group_number, group_rows) in enumerate(self.group_data_SD.items()):
-                group_x = []
-                group_y = []
-
-                for row_data in group_rows:
-                    try:
-                        # Adjust these indexes as per your group data structure
-                        x_val = float(row_data[2])  # e.g., x value
-                        y_val = float(row_data[column])
-                        group_x.append(x_val)
-                        group_y.append(y_val)
-                    except (ValueError, IndexError):
-                        continue
-
-                sorted_points = sorted(zip(group_x, group_y), key=lambda p: p[0])
-                if len(sorted_points) > 1:
-                    xs, ys = zip(*sorted_points)
-                    color = self.tab10_colors[i % len(self.tab10_colors)]
-
-                    graph.plot(
-                        xs, ys,
-                        pen={'color': color, 'width': 2},
-                        symbol='o',
-                        symbolBrush=color,
-                        symbolPen=None,
-                        symbolSize=8
-                    )
-
-    # Eact
-    def plot_Arr(self):
-        self.ui.groupBox_EAct.setHidden(False)
-        table = self.ui.table_SE
-        graph = self.ui.SEWidget
-
-        Temperature = np.array(self.read_column_values(table, 0))
-        T2 = np.array(self.read_column_values(table, 3))
-
-        sorted_indices = np.argsort(Temperature)
-        Temperature = Temperature[sorted_indices]
-        T2 = T2[sorted_indices]
-
-        if self.ui.checkBox_5.isChecked():
-            Temperature = Temperature + 273.15 #Transfer to K
-
-        starting_point = int(self.ui.Eact_start.value())
-        ending_point = -(int(self.ui.Eact_end.value()))
-        if ending_point == 0:
-            ending_point = None
-        try:
-            Temperature = Temperature[starting_point:ending_point]
-            T2 = T2[starting_point:ending_point]
-            reciprocal_temperature, lnT2 = Cal.calculate_Arrhenius_ax(Temperature, T2)
-            # fit linear
-            Temp_fit, fitted_curve, Eact, R2 = Cal.calculate_Eact(reciprocal_temperature, lnT2, self.ui.radioButton_8.isChecked())
-
-            graph.clear()
-            graph.plot(reciprocal_temperature, lnT2, pen=None, symbol='o', symbolPen=None, symbolBrush=(255, 0, 0, 255), symbolSize=10)
-            graph.plot(Temp_fit, fitted_curve, pen='b')
-            self.setup_graph(graph, "1000/T, 𝐾⁻¹", "ln(τ)", "")
-
-            self.ui.textEdit_EAct.setText(f"Eact = {Eact}\nR² {R2}")
-
-        except Exception as e:
-            QMessageBox.warning(self, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
-
-    def hide_Eact(self):
-        self.ui.groupBox_EAct.setHidden(True)
-        self.ui.SEWidget.clear()
-        self.setup_graph(self.ui.SEWidget, "", "", "")
-        self.update_xaxis(self.ui.table_SE, 0)
-
     # Math procedures
     def FFT_handmade(self, Fid, Time, Freq):
         N = len(Freq)
@@ -2330,262 +893,3 @@ class MainWindow(QMainWindow):
             Fur[i] = np.sum(Fid * (cos_values[:, i] - 1j * sin_values[:, i]))
         QCoreApplication.processEvents()
         return Fur
-
-class SaveFilesDialog(QFileDialog):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setAcceptMode(QFileDialog.AcceptSave)  # Set the dialog to save mode
-
-    def save_data_as_csv(self, directory, table, files, default_filename):
-        # I have no fucjing idea, why the hell this function takes these arguments, but it doesn't work otherwise.
-        try:
-            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\MyApp", 0, winreg.KEY_READ)
-            directory, _ = winreg.QueryValueEx(key, "SelectedFolder")
-            winreg.CloseKey(key)
-        except FileNotFoundError:
-            return os.path.dirname(sys.argv[0])
-        except Exception as e:
-            print(f"Couldn't read the initial directory: {e}")
-            return os.path.dirname(sys.argv[0])
-
-
-        options = QFileDialog.Options()
-        file_path, _ = QFileDialog.getSaveFileName(self, "Save File As", directory + '/' + default_filename, "CSV files (*.csv)", options=options)
-
-        if file_path:
-            try:
-                with open(file_path, 'w') as f:
-                    for row in range(table.rowCount()):
-                        row_values = []
-                        for col in range(table.columnCount()):
-                            item = table.item(row, col)
-                            if item is not None:
-                                row_values.append(item.text())
-                            else:
-                                row_values.append("")  # Handle empty cells
-                        f.write(','.join(row_values) + '\n')
-
-                files_list_path = os.path.splitext(file_path)[0] + '_files.json'
-
-                with open(files_list_path, 'w') as file_list:
-                    json.dump(files, file_list)
-
-            except Exception as e:
-                print(f"Failed to save file as CSV: {e}")
-
-    def save_file_in_sef(self, wtf, dictionary, tau, n, begin, save):
-        if save == False:
-            return
-
-        try:
-            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\MyApp", 0, winreg.KEY_READ)
-            directory, _ = winreg.QueryValueEx(key, "SelectedFolder")
-            winreg.CloseKey(key)
-        except FileNotFoundError:
-            return os.path.dirname(sys.argv[0])
-        except Exception as e:
-            print(f"Couldn't read the initial directory: {e}")
-            return os.path.dirname(sys.argv[0])
-
-        try:
-            options = QFileDialog.Options()
-            default_add = '_recalculated_tau_' + str(n)
-            file_path, _ = QFileDialog.getSaveFileName(self, "Save File As", directory + '/'+ begin + default_add, "SEF files (*.sef)", options=options)
-            with open(file_path, 'w') as f:
-                f.write('STELAR Export File\n')  
-                f.write('\n')  
-                f.write('_BRLX______\t_T1________\t_R1________\t____%err___\t+-err(R1)__\tZone\tFile\n')  
-                f.write('\n')
-                for key in dictionary:
-                    Frequency = dictionary[key]['X Axis']
-                    T1 = dictionary[key][tau]
-                    if T1 == 0:
-                        Omega_1 = 0
-                    else:
-                        Omega_1 = 1000/T1
-                    f.write(f'{Frequency}\t{T1}\t{Omega_1}\n')
-        except:
-            QMessageBox.warning(self, "Save failed", f"Sorry, couldn't save the separate file in .sef for magnetization.", QMessageBox.Ok)
-            return
-        #TODO: try to find reasons for that maybe? 
-        # When the load happends, there is no key T1 1 created in dictionary
-        # So ppb should read value from the table
-
-class PhasingManual(QDialog):
-    # TODO somehow create an araay of ORIGINAL Re_spectra and be able to restore it...
-    closed = Signal()
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.ui = Ui_PhasingManual()
-        self.ui.setupUi(self)
-
-        graph_phasing = self.ui.PhasingGraph
-        graph_phasing.getAxis('bottom').setLabel("Frequency, MHz")
-        graph_phasing.getAxis('left').setLabel("Amplitude, a.u.")
-        graph_phasing.setTitle("Phasing")
-        self.ui.PhasingGraph.addLegend()
-
-        self.ui.pushButton_2.clicked.connect(self.zero)
-        self.ui.verticalSlider_a.valueChanged.connect(self.value_changed)
-        self.ui.verticalSlider_b.valueChanged.connect(self.value_changed)
-        self.ui.verticalSlider_c.valueChanged.connect(self.value_changed)
-        self.ui.verticalSlider_d.valueChanged.connect(self.value_changed)
-        self.ui.dial.valueChanged.connect(self.smoothing_changed)
-        self.ui.pushButton_3.clicked.connect(self.manual_read)
-        self.ui.pushButton.clicked.connect(self.save_data)
-
-        self.Real_freq_phased = None
-
-    def read_data(self):
-        global Frequency, Re_spectra, Im_spectra
-
-        self.zero()
-
-    def save_data(self):
-        global Re_spectra
-
-        if self.Real_freq_phased is not None:
-            Re_spectra = self.Real_freq_phased
-        else:
-            Re_spectra = Re_spectra
-
-        self.close()
-
-    def closeEvent(self, event):
-        self.closed.emit()
-        super().closeEvent(event)
-
-    def zero(self):
-        self.a = 0
-        self.b = 0
-        self.c = 0
-        self.d = 0
-        self.Smooth = 0
-
-        self.set_zero(self.ui.verticalSlider_a, self.ui.Box_a)
-        self.set_zero(self.ui.verticalSlider_b, self.ui.Box_b)
-        self.set_zero(self.ui.verticalSlider_c, self.ui.Box_c)
-        self.set_zero(self.ui.verticalSlider_d, self.ui.Box_d)
-
-        self.ui.dial.setValue(0)
-        self.ui.Box_smooth.setValue(0)
-
-        if self.Real_freq_phased is not None:
-            self.process_data()
-
-    def set_zero(self,slider,box):
-        slider.setValue(0)
-        box.setValue(0)
-
-    def process_data(self):
-        self.Real_freq_phased = self.calculate_phase()
-        self.update_plot()
-        self.update_text()
-
-    def calculate_phase(self):
-        global Frequency, Re_spectra, Im_spectra
-        phi = self.a + self.b * Frequency + self.c * Frequency ** 2 + self.d * Frequency ** 3
-        self.Real_freq_phased = Re_spectra * np.cos(np.deg2rad(phi)) - Im_spectra * np.sin(np.deg2rad(phi))
-
-        if self.Smooth > 1:
-            self.Smooth = int(self.Smooth)
-            self.Real_freq_phased = self.smooth(self.Real_freq_phased)
-
-        return self.Real_freq_phased
-
-    def smooth(self,y,):
-        new_array = savgol_filter(y, window_length=self.Smooth, polyorder=1)
-        # print(self.Smooth)
-
-        return new_array
-
-    def update_plot(self):
-        global Frequency, Re_spectra, Im_spectra
-
-        self.ui.PhasingGraph.clear()
-        self.ui.PhasingGraph.plot(Frequency, Re_spectra, pen='r', name = 'Original') #Real origin
-        self.ui.PhasingGraph.plot(Frequency, self.Real_freq_phased, pen='b', name = 'Phased') #Real phased
-
-    def update_text(self):
-        global Frequency
-        Integral = np.trapz(self.Real_freq_phased)
-        left_mean = np.mean(self.Real_freq_phased[:100])
-        right_mean = np.mean(self.Real_freq_phased[-100:])
-        delta = left_mean - right_mean
-
-        self.ui.Integral.setText(f"Integral: {round(Integral,3)}")
-        self.ui.Delta.setText(f"Delta: {round(delta,7)}")
-
-        Real_apod   = Cal._calculate_apodization(self.Real_freq_phased, Frequency)
-        M2, T2 = Cal._calculate_M2(Real_apod, Frequency)
-
-        self.ui.M2.setText(f"M₂: {round(M2,5)}")
-        self.ui.T2.setText(f"T₂*: {round(T2,3)}")
-
-    def value_changed(self):
-        global Frequency, Re_spectra, Im_spectra
-
-        self.a = self.ui.verticalSlider_a.value()
-        self.b = self.ui.verticalSlider_b.value()
-        self.c = self.ui.verticalSlider_c.value()
-        self.d = self.ui.verticalSlider_d.value()
-
-        self.ui.Box_a.setValue(self.a)
-        self.ui.Box_b.setValue(self.b)
-        self.ui.Box_c.setValue(self.c)
-        self.ui.Box_d.setValue(self.d)
-
-        self.check_borders(self.ui.verticalSlider_a)
-        self.check_borders(self.ui.verticalSlider_b)
-        self.check_borders(self.ui.verticalSlider_c)
-        self.check_borders(self.ui.verticalSlider_d)
-
-
-        if Frequency is not None and Re_spectra is not None and Im_spectra is not None:
-            self.process_data()
-        else:
-            return
-
-    def check_borders(self, slider):
-        max = slider.maximum()
-        min = slider.minimum()
-
-        val = slider.value()
-
-        if val + 10 > max:
-            slider.setMaximum(val+10)
-        elif val - 10 < min:
-            slider.setMinimum(val-10)
-
-    def smoothing_changed(self):
-        self.Smooth = self.ui.dial.value()
-        self.ui.Box_smooth.setValue(self.Smooth)
-        self.process_data()
-
-    def manual_read(self):
-        self.a = self.ui.Box_a.value()
-        self.b = self.ui.Box_b.value()
-        self.c = self.ui.Box_c.value()
-        self.d = self.ui.Box_d.value()
-        self.Smooth = self.ui.Box_smooth.value()
-
-        self.ui.verticalSlider_a.valueChanged.disconnect(self.value_changed)
-        self.ui.verticalSlider_b.valueChanged.disconnect(self.value_changed)
-        self.ui.verticalSlider_c.valueChanged.disconnect(self.value_changed)
-        self.ui.verticalSlider_d.valueChanged.disconnect(self.value_changed)
-        self.ui.dial.valueChanged.disconnect(self.smoothing_changed)
-
-        self.ui.dial.setValue(self.Smooth)
-        self.ui.verticalSlider_a.setValue(self.a)
-        self.ui.verticalSlider_b.setValue(self.b)
-        self.ui.verticalSlider_c.setValue(self.c)
-        self.ui.verticalSlider_d.setValue(self.d)
-
-        self.process_data()
-
-        self.ui.verticalSlider_a.valueChanged.connect(self.value_changed)
-        self.ui.verticalSlider_b.valueChanged.connect(self.value_changed)
-        self.ui.verticalSlider_c.valueChanged.connect(self.value_changed)
-        self.ui.verticalSlider_d.valueChanged.connect(self.value_changed)
-        self.ui.dial.valueChanged.connect(self.smoothing_changed)
-

--- a/plotting/common_plots.py
+++ b/plotting/common_plots.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/plotting/dq_plots.py
+++ b/plotting/dq_plots.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/plotting/dqmq_plots.py
+++ b/plotting/dqmq_plots.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/plotting/graph_setup.py
+++ b/plotting/graph_setup.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/plotting/gs_plots.py
+++ b/plotting/gs_plots.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/plotting/se_plots.py
+++ b/plotting/se_plots.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/plotting/t1t2_plots.py
+++ b/plotting/t1t2_plots.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/services/export_service.py
+++ b/services/export_service.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/services/file_service.py
+++ b/services/file_service.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/services/registry_service.py
+++ b/services/registry_service.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/services/save_load_service.py
+++ b/services/save_load_service.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""

--- a/services/update_service.py
+++ b/services/update_service.py
@@ -1,1 +1,0 @@
-"""Module scaffold for refactor."""


### PR DESCRIPTION
### Motivation
- Split large monolithic UI logic into reusable controller classes and centralize shared state to improve maintainability and testability.
- Replace placeholder scaffolding modules with concrete implementations for SE, DQ, DQTemp, DQMQ, GS and T1T2 behaviors and consolidate phasing and save/load dialogs.
- Add lightweight function call tracing to help diagnose runtime issues during development.

### Description
- Introduced `controllers/base_tab_controller.py` and concrete controllers `se_controller.py`, `dq_controller.py`, `dq_temp_controller.py`, `dqmq_controller.py`, `gs_controller.py`, `t1t2_controller.py` and `general_se_dq_controller.py`, moving logic out of `main_window.py` and into dedicated classes while preserving UI interactions.
- Updated `main_window.py` to create controller instances, wire UI signals to controller methods, use an `AppState` (via `app_state`) to share file lists, and remove several in-class implementations (DQ/SE/T1/G S/DQMQ logic) in favor of controllers.
- Added `dialogs/save_files_dialog.py` and enhanced `dialogs/open_files_dialog.py` and `dialogs/phasing_manual.py` to handle file saving/loading and manual phasing with the refactored controllers.
- Added `logging_system.py` and installed a function profiler call in `main.py` to log entry into repo code functions and hints about file-like locals.
- Implemented helpers for plotting/reading/table population inside controllers and removed many placeholder scaffolding modules that are no longer needed.

### Testing
- No automated tests were executed as part of this change; this patch focuses on a large refactor and adds new modules but does not include new unit tests in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b58e35f083278c94d25b2af6b308)