### PR TITLE
Fix Arrhenius fit robustness and avoid Qt debug backend import issue

### DIFF
--- a/Calculator.py
+++ b/Calculator.py
@@ -5,7 +5,6 @@
 import numpy as np
 from scipy.optimize import curve_fit
 from scipy.signal import savgol_filter
-import matplotlib.pyplot as plt
 from sympy import symbols, diff, solve
 
 # Math procedures

--- a/controllers/se_controller.py
+++ b/controllers/se_controller.py
@@ -86,6 +86,14 @@ class SETabController(BaseTabController):
         try:
             Temperature = Temperature[starting_point:ending_point]
             T2 = T2[starting_point:ending_point]
+
+            valid_mask = np.isfinite(Temperature) & np.isfinite(T2) & (T2 > 0)
+            Temperature = Temperature[valid_mask]
+            T2 = T2[valid_mask]
+
+            if len(Temperature) < 2:
+                raise ValueError("Not enough valid points for Arrhenius fit (need at least 2 positive T₂* values).")
+
             reciprocal_temperature, lnT2 = Cal.calculate_Arrhenius_ax(Temperature, T2)
             Temp_fit, fitted_curve, Eact, R2 = Cal.calculate_Eact(reciprocal_temperature, lnT2, self.ui.radioButton_8.isChecked())
             graph.clear()
@@ -94,7 +102,7 @@ class SETabController(BaseTabController):
             self.parent.setup_graph(graph, "1000/T, 𝐾⁻¹", "ln(τ)", "")
             self.ui.textEdit_EAct.setText(f"Eact = {Eact}\nR² {R2}")
         except Exception as e:
-            QMessageBox.warning(self.parent, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
+            QMessageBox.warning(self.parent, "Arrhenius fit error", str(e), QMessageBox.Ok)
 
     def hide_Eact(self):
         self.ui.groupBox_EAct.setHidden(True)


### PR DESCRIPTION
### Motivation
- Prevent spurious Qt backend initialization during debug sessions that can trigger debugpy’s Qt integration path and the `ModuleNotFoundError: No module named 'imp'` traceback. 
- Make activation-energy (Arrhenius) plotting robust to bad or missing `T2` data and provide actionable UI feedback when fitting cannot proceed.

### Description
- Removed the unused `matplotlib.pyplot` import from `Calculator.py` to avoid unnecessary backend initialization at import time. 
- In `controllers/se_controller.py::plot_Arr` filter out non-finite and non-positive values with `valid_mask = np.isfinite(Temperature) & np.isfinite(T2) & (T2 > 0)` before performing the Arrhenius transform and fit. 
- Add a validation that raises a clear `ValueError` when fewer than two valid points remain so the fit is not attempted on insufficient data. 
- Replace the generic error dialog with a specific message title and the exception text by using `QMessageBox.warning(self.parent, "Arrhenius fit error", str(e), QMessageBox.Ok)`.

### Testing
- Ran `python -m py_compile controllers/se_controller.py Calculator.py` to verify syntax and byte-compile both modified modules, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e6fa9bf0832794b377aa23a1c707)