### PR TITLE
Persist manual phasing per-file; save/load phased spectra; improve DQ/SE controllers and file management

### DIFF
--- a/Calculator.py
+++ b/Calculator.py
@@ -5,7 +5,6 @@
 import numpy as np
 from scipy.optimize import curve_fit
 from scipy.signal import savgol_filter
-import matplotlib.pyplot as plt
 from sympy import symbols, diff, solve
 
 # Math procedures

--- a/controllers/dq_controller.py
+++ b/controllers/dq_controller.py
@@ -20,10 +20,9 @@ class DQTabController(BaseTabController):
         self.update_graphs()
 
     def update_graphs(self):
-        files = getattr(getattr(self.state, "dq", None), "files", None)
-        if files is None:
-            files = getattr(self.state, "dq_files", [])
-        if len(files) > 1:
+        dq_time = self.read_column_values(self.ui.table_DQ, 0)
+        t2_values = self.read_column_values(self.ui.table_DQ, 3)
+        if len(dq_time) > 1 and len(t2_values) > 1:
             self.linearization()
             self.plot_fit()
         else:

--- a/controllers/general_se_dq_controller.py
+++ b/controllers/general_se_dq_controller.py
@@ -60,6 +60,12 @@ class GeneralSEDQController(BaseTabController):
         if mw.window_array.size!=0:
             window=mw.window_array[i-1]; FFT=np.array(savgol_filter(np.real(FFT),window,1)+1j*savgol_filter(np.imag(FFT),window,1))
         amp_spectra,re_spectra,im_spectra=Cal._simple_baseline_correction(FFT); Real_apod=Cal._calculate_apodization(re_spectra,frequency)
+        phased_store = mw.phased_spectra_SE if mw.tab == 'SE' else mw.phased_spectra_DQ
+        phased_record = phased_store.get(filename)
+        if phased_record:
+            re_spectra = np.array(phased_record.get("re", re_spectra))
+            im_spectra = np.array(phased_record.get("im", im_spectra))
+            Real_apod = Cal._calculate_apodization(re_spectra, frequency)
         self.state.spectrum.frequency = frequency
         self.state.spectrum.re_spectra = re_spectra
         self.state.spectrum.im_spectra = im_spectra
@@ -75,9 +81,22 @@ class GeneralSEDQController(BaseTabController):
     def after_phasing(self):
         mw=self.parent
         i=self.ui.comboBox_4.currentIndex()
+        if i < 0:
+            return
         frequency = self.state.spectrum.frequency
         re_spectra = self.state.spectrum.re_spectra
         im_spectra = self.state.spectrum.im_spectra
+        phased_window = getattr(mw, "phasing_manual_window", None)
+        if phased_window is not None and getattr(phased_window, "Real_freq_phased", None) is not None:
+            re_spectra = phased_window.Real_freq_phased
+            self.state.spectrum.re_spectra = re_spectra
+            self.state.spectrum.im_spectra = np.zeros_like(re_spectra)
+            im_spectra = self.state.spectrum.im_spectra
+        filename = self.ui.comboBox_4.currentText()
+        if mw.tab == 'SE' and filename:
+            mw.phased_spectra_SE[filename] = {"re": re_spectra.tolist(), "im": im_spectra.tolist()}
+        elif mw.tab == 'DQ' and filename:
+            mw.phased_spectra_DQ[filename] = {"re": re_spectra.tolist(), "im": im_spectra.tolist()}
         Real_apod=Cal._calculate_apodization(re_spectra,frequency); Amp_spectra=Cal._calculate_amplitude(re_spectra,im_spectra)
         mw.update_graphs(frequency,Amp_spectra,re_spectra,im_spectra,self.ui.FFTWidget); M2,T2=Cal._calculate_M2(Real_apod,frequency)
         table=self.ui.table_SE if mw.tab=='SE' else self.ui.table_DQ

--- a/controllers/se_controller.py
+++ b/controllers/se_controller.py
@@ -86,6 +86,14 @@ class SETabController(BaseTabController):
         try:
             Temperature = Temperature[starting_point:ending_point]
             T2 = T2[starting_point:ending_point]
+
+            valid_mask = np.isfinite(Temperature) & np.isfinite(T2) & (T2 > 0)
+            Temperature = Temperature[valid_mask]
+            T2 = T2[valid_mask]
+
+            if len(Temperature) < 2:
+                raise ValueError("Not enough valid points for Arrhenius fit (need at least 2 positive T₂* values).")
+
             reciprocal_temperature, lnT2 = Cal.calculate_Arrhenius_ax(Temperature, T2)
             Temp_fit, fitted_curve, Eact, R2 = Cal.calculate_Eact(reciprocal_temperature, lnT2, self.ui.radioButton_8.isChecked())
             graph.clear()
@@ -94,7 +102,7 @@ class SETabController(BaseTabController):
             self.parent.setup_graph(graph, "1000/T, 𝐾⁻¹", "ln(τ)", "")
             self.ui.textEdit_EAct.setText(f"Eact = {Eact}\nR² {R2}")
         except Exception as e:
-            QMessageBox.warning(self.parent, "Error", f"Something {e} went wrong. Try again.", QMessageBox.Ok)
+            QMessageBox.warning(self.parent, "Arrhenius fit error", str(e), QMessageBox.Ok)
 
     def hide_Eact(self):
         self.ui.groupBox_EAct.setHidden(True)

--- a/dialogs/save_files_dialog.py
+++ b/dialogs/save_files_dialog.py
@@ -9,6 +9,7 @@ class SaveFilesDialog(QFileDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setAcceptMode(QFileDialog.AcceptSave)
+        self.last_saved_file_path = None
 
     def save_data_as_csv(self, directory, table, files, default_filename):
         try:
@@ -21,6 +22,7 @@ class SaveFilesDialog(QFileDialog):
         options = QFileDialog.Options()
         file_path, _ = QFileDialog.getSaveFileName(self, "Save File As", directory + '/' + default_filename, "CSV files (*.csv)", options=options)
         if file_path:
+            self.last_saved_file_path = file_path
             with open(file_path, 'w') as f:
                 for row in range(table.rowCount()):
                     row_values = []

--- a/main_window.py
+++ b/main_window.py
@@ -76,6 +76,8 @@ class MainWindow(QMainWindow):
         self.group_data_SE = {}
         self.group_data_T1T2 = {}
         self.group_data_SD = {}
+        self.phased_spectra_SE = {}
+        self.phased_spectra_DQ = {}
         self.tab = None
         self.state_bad_code = False
         self.se_controller = SETabController(ui=self.ui, state=self.app_state, parent=self)
@@ -303,8 +305,8 @@ class MainWindow(QMainWindow):
             self.window_array = np.array([])
 
         try:
-            self.process_file_data(file_path, file_path_gly, file_path_empty, i)
-        except:
+            self.general_se_dq_controller.process_file_data(file_path, file_path_gly, file_path_empty, i)
+        except Exception:
             return
 
         # Update general figures
@@ -329,6 +331,7 @@ class MainWindow(QMainWindow):
             self.ui.FidWidget.clear()
             self.ui.btn_Start.setStyleSheet("background-color: none")
             self.group_data_SE = {}
+            self.phased_spectra_SE = {}
         elif self.tab == 'DQ':
             self.selected_files_DQ_single = []
             self.app_state.dq_files = []
@@ -341,6 +344,7 @@ class MainWindow(QMainWindow):
             self.ui.FFTWidget.clear()
             self.ui.FidWidget.clear()
             self.ui.btn_Start.setStyleSheet("background-color: none")
+            self.phased_spectra_DQ = {}
         elif self.tab == 'DQ_Temp':
             self.selected_DQfiles = []
             self.dq_t2 = {}
@@ -387,9 +391,11 @@ class MainWindow(QMainWindow):
         if self.tab == 'SE':
             table = self.ui.table_SE
             combobox = self.ui.comboBox_4
+            files = self.selected_files
         elif self.tab == 'DQ':
             table = self.ui.table_DQ
             combobox = self.ui.comboBox_4
+            files = self.selected_files_DQ_single
         elif self.tab =='T1T2':
             table = self.ui.table_T1
             combobox = self.ui.T1T2_ChooseFileComboBox
@@ -405,16 +411,32 @@ class MainWindow(QMainWindow):
         if row == -1:
             QMessageBox.warning(self, "Cricket sounds", f"Select the row.", QMessageBox.Ok)
             return
-        item = table.item(row,0).text()
+
         table.removeRow(row)
-        combobox.removeItem(row)
+        if combobox.count() > row:
+            combobox.removeItem(row)
 
         try:
-            for file_to_delete in files:
-                if file_to_delete == item:
-                    files.remove(item)
-        except:
-            QMessageBox.warning(self, "Hidden", f"The row is hidden, but the file is not deleted.", QMessageBox.Ok)
+            if files and len(files) > row:
+                files.pop(row)
+            if self.tab in ('SE', 'DQ') and self.selected_files_gly and len(self.selected_files_gly) > row:
+                self.selected_files_gly.pop(row)
+            if self.tab in ('SE', 'DQ') and self.selected_files_empty and len(self.selected_files_empty) > row:
+                self.selected_files_empty.pop(row)
+        except Exception:
+            QMessageBox.warning(self, "Delete warning", "Row was removed from table, but file lists may be out of sync.", QMessageBox.Ok)
+
+        if self.tab == 'SE':
+            self.se_controller.update_graphs()
+        elif self.tab == 'DQ':
+            self.dq_controller.update_graphs()
+
+        if self.tab in ('SE', 'DQ') and combobox.count() > 0:
+            combobox.setCurrentIndex(min(row, combobox.count() - 1))
+            self.update_file()
+        elif self.tab in ('SE', 'DQ'):
+            self.ui.FidWidget.clear()
+            self.ui.FFTWidget.clear()
 
     def highlight_row(self, table, row_selected):
 
@@ -723,6 +745,11 @@ class MainWindow(QMainWindow):
                 default_name = 'DQMQ_data_'
         dialog = SaveFilesDialog(self)
         dialog.save_data_as_csv(self, table, files, default_name)
+        if self.tab in ('SE', 'DQ') and dialog.last_saved_file_path:
+            files_json = os.path.splitext(dialog.last_saved_file_path)[0] + '_files.json'
+            phased_data = self.phased_spectra_SE if self.tab == 'SE' else self.phased_spectra_DQ
+            with open(files_json, 'w') as f:
+                json.dump({"files": files, "phased": phased_data}, f)
 
         if self.state_bad_code == True:
             self.t1t2_controller.bad_code_makes_more_bad_code()
@@ -738,25 +765,35 @@ class MainWindow(QMainWindow):
 
         self.clear_list()
         self.enable_buttons()
+        self.ui.comboBox_4.clear()
 
         file_path = tableName[0]
         try:
             files_list = file_path.strip().split('.')[0] + '_files.json'
             with open(files_list, 'r') as file:
-                files = json.load(file)
+                files_payload = json.load(file)
+                if isinstance(files_payload, dict):
+                    files = files_payload.get("files", [])
+                    phased = files_payload.get("phased", {})
+                else:
+                    files = files_payload
+                    phased = {}
         except Exception as e:
             QMessageBox.warning(self, "File missing", f"Didn't find file list, only the tabular result is available", QMessageBox.Ok)
             files = None
+            phased = {}
             self.ui.comboBox_4.setEnabled(False)
             self.ui.btn_Phasing.setEnabled(False)
 
         if self.tab == 'SE':
             table = self.ui.table_SE
             self.selected_files = files
+            self.phased_spectra_SE = phased
         elif self.tab == 'DQ':
             table = self.ui.table_DQ
             self.selected_files_DQ_single = files
             self.app_state.dq_files = files
+            self.phased_spectra_DQ = phased
         elif self.tab == 'DQ_Temp':
             table = self.ui.table_DQ_2
             self.selected_DQfiles = files
@@ -776,15 +813,28 @@ class MainWindow(QMainWindow):
             table.setRowCount(len(lines))
             for row, line in enumerate(lines):
                 values = line.strip().split(',')
-                self.ui.comboBox_4.addItem(f"File #{row+1}")
                 for col, value in enumerate(values):
                     item = QTableWidgetItem(value)
                     table.setItem(row, col, item)
 
+        if self.tab in ('SE', 'DQ'):
+            if files:
+                for path in files:
+                    self.ui.comboBox_4.addItem(os.path.basename(path))
+            else:
+                for row in range(table.rowCount()):
+                    self.ui.comboBox_4.addItem(f"File #{row+1}")
+
         if self.tab == 'SE':
             self.update_se_graphs()
+            if self.ui.comboBox_4.count() > 0:
+                self.ui.comboBox_4.setCurrentIndex(0)
+                self.update_file()
         elif self.tab == 'DQ':
             self.dq_controller.update_graphs()
+            if self.ui.comboBox_4.count() > 0:
+                self.ui.comboBox_4.setCurrentIndex(0)
+                self.update_file()
         elif self.tab == 'DQ_Temp':
             self.dq_temp_controller.update_DQ_comparison()
         elif self.tab == 'T1T2':


### PR DESCRIPTION
### Motivation
- Persist user-applied phasing between sessions and allow manual phasing to override spectral processing for individual files. 
- Improve robustness of file save/load to include auxiliary data (phased spectra) and keep file lists synchronized with UI operations. 
- Fix a few UI edge cases and provide clearer error messaging and validation for fits.

### Description
- Add per-file phased spectra storage to the main window with `phased_spectra_SE` and `phased_spectra_DQ`, record phasing in `GeneralSEDQController.after_phasing`, and apply stored phasing when processing files in `process_file_data`.
- Extend `SaveFilesDialog.save_data_as_csv` to record the last saved path and update `MainWindow.save_data` to write a companion JSON containing both `files` and `phased` spectra; update `MainWindow.load_table_from_csv` to load the new payload and populate `phased_spectra_*` and the file combobox.
- Make `GeneralSEDQController.after_phasing` robust to missing selection (`i < 0`) and allow manual phasing UI to update the stored spectra back into the app state; `process_file_data` now consults stored phasing before using computed FFTs.
- Improve row deletion in `MainWindow.delete_row` to safely pop corresponding entries from file lists and glycerol/baseline lists, and refresh graphs/UI selection after deletion.
- Change `DQTabController.update_graphs` to read values from the DQ table for plotting instead of relying on older state attributes; provide a clearer Arrhenius fit error dialog in `se_controller.plot_Arr` and validate inputs before fitting.
- Add `last_saved_file_path` attribute to `SaveFilesDialog` and minor defensive checks when populating combo boxes after loading.

### Testing
- Ran the project's automated unit test suite (`pytest`) and all tests completed successfully.
- Executed automated GUI smoke tests covering open/save/load workflows, manual phasing apply/save/load, row deletion, and DQ plotting; all scenarios passed.
- Ran the Arrhenius/linearization code paths with both valid and invalid input ranges to verify the new validation and error message behavior, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e6fa9bf0832794b377aa23a1c707)