### PR TITLE
Add interactive Dres tool launcher

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -88,11 +88,13 @@ class MainWindow(QMainWindow):
         self.dqmq_controller = DQMQTabController(ui=self.ui, state=self.app_state, parent=self)
         self.gs_controller = GSTabController(ui=self.ui, state=self.app_state, parent=self)
         self.general_se_dq_controller = GeneralSEDQController(ui=self.ui, state=self.app_state, parent=self, se_controller=self.se_controller, dq_controller=self.dq_controller)
+        self.interactive_dres_figure = None
 
         self.state()
 
         self.ui.Settings_Button_DefaultFolder.clicked.connect(self.default_folder)
         self.ui.Settings_Button_OpenProjectPage.clicked.connect(self.open_url)
+        self.ui.Settings_Button_InteractiveDres.clicked.connect(self.open_interactive_dres_tool)
         self.check_for_updates()
 
         self.ui.tabWidget.currentChanged.connect(self.state)
@@ -221,6 +223,52 @@ class MainWindow(QMainWindow):
     def open_url(self):
         """Open the GitHub releases page used by the Settings tab."""
         open_application('https://github.com/timesama/M2-Approach/releases')
+
+    def open_interactive_dres_tool(self):
+        """Open or raise the standalone interactive Dres matplotlib tool."""
+        try:
+            import matplotlib.pyplot as plt
+
+            if (
+                self.interactive_dres_figure is not None
+                and plt.fignum_exists(self.interactive_dres_figure.number)
+            ):
+                self._raise_interactive_dres_window(self.interactive_dres_figure)
+                return
+
+            from plotmat import plot_interactive_Dres as interactive_dres
+
+            self.interactive_dres_figure = interactive_dres.open_interactive_dres(parent=self)
+            self.interactive_dres_figure.canvas.mpl_connect(
+                "close_event",
+                self._clear_interactive_dres_reference,
+            )
+        except Exception:
+            logger.exception("Could not open the interactive Dres tool.")
+            self.interactive_dres_figure = None
+            QMessageBox.warning(
+                self,
+                "Interactive Dres",
+                "Could not open the interactive Dres tool.",
+                QMessageBox.Ok,
+            )
+
+    def _raise_interactive_dres_window(self, figure):
+        """Bring the existing interactive Dres matplotlib window to the front when possible."""
+        manager = getattr(figure.canvas, "manager", None)
+        window = getattr(manager, "window", None)
+        if window is not None:
+            if hasattr(window, "raise_"):
+                window.raise_()
+            if hasattr(window, "activateWindow"):
+                window.activateWindow()
+        elif manager is not None and hasattr(manager, "show"):
+            manager.show()
+
+    def _clear_interactive_dres_reference(self, event):
+        """Forget the Dres figure after matplotlib has closed it."""
+        if event.canvas.figure is self.interactive_dres_figure:
+            self.interactive_dres_figure = None
 
     def update_file(self):
         """Load the selected SE/DQ file into the shared FID/FFT preview widgets."""

--- a/plotmat/plot_interactive_Dres.py
+++ b/plotmat/plot_interactive_Dres.py
@@ -30,11 +30,13 @@ def P_gaussian(D, mu, sigma):
     P = np.exp(-(D - mu) ** 2 / (2 * sigma ** 2))
     return normalize(P, D)
 
+
 def P_abragam(D, D0, w):
     w = max(w, 1e-6)
     P = (D / w**2) * np.exp(-(D - D0) ** 2 / (2 * w**2))
     P[P < 0] = 0
     return normalize(P, D)
+
 
 def P_weibull(D, lam, beta):
     lam = max(lam, 1e-12)
@@ -44,6 +46,7 @@ def P_weibull(D, lam, beta):
     P[D <= 0] = 0
 
     return normalize(P, D)
+
 
 def P_pake(D, D0, w):
     # Pake-like singular distribution, regularized by small epsilon
@@ -58,23 +61,29 @@ def P_pake(D, D0, w):
 
     return normalize(P, D)
 
+
 def P_gaussian_mix2(D, mu1, sigma1, mu2, sigma2, frac1):
     return frac1 * P_gaussian(D, mu1, sigma1) + (1 - frac1) * P_gaussian(D, mu2, sigma2)
+
 
 def P_abragam_mix2(D, D01, w1, D02, w2, frac1):
     return frac1 * P_abragam(D, D01, w1) + (1 - frac1) * P_abragam(D, D02, w2)
 
+
 def P_pake_mix2(D, D01, w1, D02, w2, frac1):
     return frac1 * P_pake(D, D01, w1) + (1 - frac1) * P_pake(D, D02, w2)
+
 
 def P_weibull_mix2(D, lam1, beta1, lam2, beta2, frac1):
     return frac1 * P_weibull(D, lam1, beta1) + (1 - frac1) * P_weibull(D, lam2, beta2)
 
+
 # -----------------------------
 # nDQ models
 # -----------------------------
-def ndq_from_distribution(t, P, kernel_model):
+def ndq_from_distribution(t, P, kernel_model, beta=2.0):
     result = []
+    beta = max(beta, 1e-12)
 
     for tau_i in t:
         x = D_grid * tau_i
@@ -89,14 +98,10 @@ def ndq_from_distribution(t, P, kernel_model):
             kernel = 1 - np.exp(-k * x**2) * np.cos(x)
 
         elif kernel_model == "Weibull":
-            beta = s6.val
-            beta = max(beta, 1e-12)
-            kernel = 1 - np.exp(-k * (x) ** beta)
+            kernel = 1 - np.exp(-k * x**beta)
 
         elif kernel_model == "A-L":
-            beta = s6.val
-            beta = max(beta, 1e-12)
-            kernel = 1 - (np.exp((-k * (x) ** beta)) * np.cos(x))
+            kernel = 1 - (np.exp(-k * x**beta) * np.cos(x))
 
         else:
             raise ValueError("Unknown kernel model")
@@ -105,111 +110,149 @@ def ndq_from_distribution(t, P, kernel_model):
 
     return np.array(result)
 
-def compute_curve():
-    kernel_model = radio_model.value_selected
-    order = radio_order.value_selected
 
-    mu1 = s1.val
-    sigma1 = s2.val
-    mu2 = s3.val
-    sigma2 = s4.val
-    frac1 = s5.val
+def open_interactive_dres(parent=None):
+    """Open the interactive Dres matplotlib tool and return its figure."""
+    # -----------------------------
+    # Figure layout
+    # -----------------------------
+    fig, (ax_curve, ax_dist) = plt.subplots(1, 2, figsize=(12, 7))
+    if fig.canvas.manager is not None:
+        fig.canvas.manager.set_window_title("Interactive Dres")
+    fig.subplots_adjust(left=0.28, bottom=0.4)
 
-    if order == "1D":
-        P = P_gaussian(D_grid, mu1, sigma1)
+    ndq0 = np.zeros_like(tau)
+    P0 = np.zeros_like(D_grid)
 
-    elif order == "2D":
-        P = P_gaussian_mix2(D_grid, mu1, sigma1, mu2, sigma2, frac1)
+    (line_curve,) = ax_curve.plot(tau, ndq0, lw=2)
+    (line_dist,) = ax_dist.plot(D_grid / (2 * np.pi) * 1000, P0, lw=2)
 
-    else:
-        raise ValueError("Unknown distribution order")
+    ax_curve.set_xlabel(r"$\tau_{DQ}$, $\mu$s")
+    ax_curve.set_ylabel(r"$I_{nDQ}$")
+    ax_curve.set_xlim(0, 100)
+    ax_curve.set_ylim(0, 0.55)
+    ax_curve.grid(True)
 
-    ndq = ndq_from_distribution(tau, P, kernel_model)
-    return ndq, P
+    ax_dist.set_xlabel(r"$D_{res}/2\pi$, kHz")
+    ax_dist.set_ylabel(r"$P(D_{res})$")
+    ax_dist.set_xlim(0, 100)
+    ax_dist.grid(True)
+
+    # -----------------------------
+    # Sliders
+    # -----------------------------
+    ax_s1 = fig.add_axes([0.28, 0.28, 0.55, 0.03])
+    ax_s2 = fig.add_axes([0.28, 0.24, 0.55, 0.03])
+    ax_s3 = fig.add_axes([0.28, 0.20, 0.55, 0.03])
+    ax_s4 = fig.add_axes([0.28, 0.16, 0.55, 0.03])
+    ax_s5 = fig.add_axes([0.28, 0.12, 0.55, 0.03])
+    ax_s6 = fig.add_axes([0.28, 0.08, 0.55, 0.03])
+
+    s1 = Slider(ax_s1, "center 1", 0.001, 0.5, valinit=0.15, valstep=0.001)
+    s2 = Slider(ax_s2, "width 1", 0.000000001, 0.1, valinit=0.001, valstep=0.000000001)
+    s3 = Slider(ax_s3, "center 2", 0.1, 0.5, valinit=0.35, valstep=0.001)
+    s4 = Slider(ax_s4, "width 2", 0.000000001, 0.1, valinit=0.001, valstep=0.000000001)
+    s5 = Slider(ax_s5, "fraction 1", 0.0, 1.0, valinit=0.5, valstep=0.001)
+    s6 = Slider(ax_s6, "Weibull beta", 0.1, 5.0, valinit=2.0, valstep=0.01)
+
+    # -----------------------------
+    # Radio buttons
+    # -----------------------------
+    ax_radio_model = fig.add_axes([0.04, 0.62, 0.16, 0.16])
+    radio_model = RadioButtons(
+        ax_radio_model,
+        ["Gaussian", "Abragam", "Pake", "Weibull", "A-L"],
+    )
+
+    ax_radio_order = fig.add_axes([0.04, 0.42, 0.16, 0.14])
+    radio_order = RadioButtons(ax_radio_order, ["1D", "2D"])
+
+    def compute_curve():
+        kernel_model = radio_model.value_selected
+        order = radio_order.value_selected
+
+        mu1 = s1.val
+        sigma1 = s2.val
+        mu2 = s3.val
+        sigma2 = s4.val
+        frac1 = s5.val
+        beta = s6.val
+
+        if order == "1D":
+            P = P_gaussian(D_grid, mu1, sigma1)
+
+        elif order == "2D":
+            P = P_gaussian_mix2(D_grid, mu1, sigma1, mu2, sigma2, frac1)
+
+        else:
+            raise ValueError("Unknown distribution order")
+
+        ndq = ndq_from_distribution(tau, P, kernel_model, beta=beta)
+        return ndq, P
+
+    # -----------------------------
+    # Update function
+    # -----------------------------
+    def update(_=None):
+        ndq, P = compute_curve()
+
+        line_curve.set_ydata(ndq)
+        line_dist.set_ydata(P)
+
+        max_p = max(P)
+        ax_dist.set_ylim(0, max_p * 1.1 if max_p > 0 else 1)
+
+        model = radio_model.value_selected
+        order = radio_order.value_selected
+
+        ax_curve.set_title(f"{model} {order}")
+        ax_dist.set_title(r"$P(D_{res})$")
+
+        fig.canvas.draw_idle()
+
+    slider_callback_ids = []
+    for slider in [s1, s2, s3, s4, s5, s6]:
+        slider_callback_ids.append((slider, slider.on_changed(update)))
+
+    radio_callback_ids = [
+        (radio_model, radio_model.on_clicked(update)),
+        (radio_order, radio_order.on_clicked(update)),
+    ]
+
+    fig._interactive_dres_widgets = {
+        "sliders": [s1, s2, s3, s4, s5, s6],
+        "radio_model": radio_model,
+        "radio_order": radio_order,
+        "slider_callback_ids": slider_callback_ids,
+        "radio_callback_ids": radio_callback_ids,
+    }
+    fig._interactive_dres_closing = False
+
+    def on_close(event):
+        closing_figure = event.canvas.figure
+        if getattr(closing_figure, "_interactive_dres_closing", False):
+            return
+
+        closing_figure._interactive_dres_closing = True
+        widgets = getattr(closing_figure, "_interactive_dres_widgets", {}) or {}
+        for widget, callback_id in widgets.get("slider_callback_ids", []):
+            widget.disconnect(callback_id)
+            widget.disconnect_events()
+        for radio, callback_id in widgets.get("radio_callback_ids", []):
+            radio.disconnect(callback_id)
+            radio.disconnect_events()
+        closing_figure._interactive_dres_widgets = None
+        if plt.fignum_exists(closing_figure.number):
+            plt.close(closing_figure)
+
+    close_cid = fig.canvas.mpl_connect("close_event", on_close)
+    fig._interactive_dres_close_cid = close_cid
+
+    update()
+    fig.show()
+    plt.show(block=False)
+    return fig
 
 
-# -----------------------------
-# Figure layout
-# -----------------------------
-fig, (ax_curve, ax_dist) = plt.subplots(1, 2, figsize=(12, 7))
-plt.subplots_adjust(left=0.28, bottom=0.4)
-
-ndq0, P0 = compute_curve() if False else (
-    np.zeros_like(tau),
-    np.zeros_like(D_grid),
-)
-
-line_curve, = ax_curve.plot(tau, ndq0, lw=2)
-line_dist, = ax_dist.plot(D_grid / (2 * np.pi) * 1000, P0, lw=2)
-
-ax_curve.set_xlabel(r"$\tau_{DQ}$, $\mu$s")
-ax_curve.set_ylabel(r"$I_{nDQ}$")
-ax_curve.set_xlim(0, 100)
-ax_curve.set_ylim(0, 0.55)
-ax_curve.grid(True)
-
-ax_dist.set_xlabel(r"$D_{res}/2\pi$, kHz")
-ax_dist.set_ylabel(r"$P(D_{res})$")
-ax_dist.set_xlim(0, 100)
-ax_dist.grid(True)
-
-
-# -----------------------------
-# Sliders
-# -----------------------------
-ax_s1 = plt.axes([0.28, 0.28, 0.55, 0.03])
-ax_s2 = plt.axes([0.28, 0.24, 0.55, 0.03])
-ax_s3 = plt.axes([0.28, 0.20, 0.55, 0.03])
-ax_s4 = plt.axes([0.28, 0.16, 0.55, 0.03])
-ax_s5 = plt.axes([0.28, 0.12, 0.55, 0.03])
-ax_s6 = plt.axes([0.28, 0.08, 0.55, 0.03])
-
-
-s1 = Slider(ax_s1, "center 1", 0.001, 0.5, valinit=0.15, valstep=0.001)
-s2 = Slider(ax_s2, "width 1", 0.000000001, 0.1, valinit=0.001, valstep=0.000000001)
-s3 = Slider(ax_s3, "center 2", 0.1, 0.5, valinit=0.35, valstep=0.001)
-s4 = Slider(ax_s4, "width 2", 0.000000001, 0.1, valinit=0.001, valstep=0.000000001)
-s5 = Slider(ax_s5, "fraction 1", 0.0, 1.0, valinit=0.5, valstep=0.001)
-s6 = Slider(ax_s6, "Weibull beta", 0.1, 5.0, valinit=2.0, valstep=0.01)
-
-# -----------------------------
-# Radio buttons
-# -----------------------------
-ax_radio_model = plt.axes([0.04, 0.62, 0.16, 0.16])
-radio_model = RadioButtons(
-    ax_radio_model,
-    ["Gaussian", "Abragam", "Pake", "Weibull", "A-L"]
-)
-
-ax_radio_order = plt.axes([0.04, 0.42, 0.16, 0.14])
-radio_order = RadioButtons(ax_radio_order, ["1D", "2D"])
-
-
-# -----------------------------
-# Update function
-# -----------------------------
-def update(_=None):
-    ndq, P = compute_curve()
-
-    line_curve.set_ydata(ndq)
-    line_dist.set_ydata(P)
-
-    ax_dist.set_ylim(0, max(P) * 1.1 if max(P) > 0 else 1)
-
-    model = radio_model.value_selected
-    order = radio_order.value_selected
-
-    ax_curve.set_title(f"{model} {order}")
-    ax_dist.set_title(r"$P(D_{res})$")
-
-    fig.canvas.draw_idle()
-
-
-for slider in [s1, s2, s3, s4, s5, s6]:
-    slider.on_changed(update)
-
-radio_model.on_clicked(update)
-radio_order.on_clicked(update)
-
-update()
-plt.show()
+if __name__ == "__main__":
+    open_interactive_dres()


### PR DESCRIPTION
### Motivation
- Expose the standalone matplotlib interactive Dres tool from the Settings tab without opening a figure at import time.
- Ensure only one interactive Dres window is active at a time and that the figure and its widget callbacks are reliably cleaned up on close.
- Preserve the original scientific calculations and interactive controls (sliders, radio buttons, nDQ and Dres curves) while keeping the main Qt app responsive.

### Description
- Refactored `plotmat/plot_interactive_Dres.py` into a callable launcher `open_interactive_dres(parent=None)` and added a guarded script entry point `if __name__ == "__main__": open_interactive_dres()` so importing the module does not show a figure.
- Moved all figure creation into the launcher and retained the same two-panel layout, sliders, radio buttons, distributions, `np.trapezoid`/`np.trapz` fallback, and update logic, while using `fig.show()` / `plt.show(block=False)` to avoid blocking the Qt app.
- Added widget retention on the figure (`fig._interactive_dres_widgets`) and a `close_event` handler that disconnects callbacks, clears widget references, and closes the specific figure to avoid ghost figures or stale state.
- Updated `MainWindow` in `mainwindow.py` to track a single active figure (`self.interactive_dres_figure`), wire `Settings_Button_InteractiveDres.clicked` to `open_interactive_dres_tool`, implement raising/reuse behavior for an existing figure, and add exception handling with `logger.exception` and a `QMessageBox.warning` fallback.

### Testing
- Ran byte-compile on the codebase with `python -m py_compile main.py mainwindow.py controllers/*.py dialogs/*.py utils/*.py calculations/*.py plotmat/*.py` and it completed successfully.
- Attempted an import/figure existence smoke test for `plotmat.plot_interactive_Dres` but it failed in this environment because `matplotlib` is not installed here, so GUI tests could not be executed automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc26c1dd48327ad7ff2aefa67b627)