### PR TITLE
Integrate Build‑up FID into g_RecFID tab (controller, calculations, dialogs)

### DIFF
--- a/calculations/recfid_signal.py
+++ b/calculations/recfid_signal.py
@@ -1,0 +1,477 @@
+"""Numerical helpers for reconstructing FIDs from build-up FID/RecFID data.
+
+This module contains no Qt/UI code.  It is a cleaned-up, application-local
+version of the old standalone BuildUpFID ``Math.py`` pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+from scipy.optimize import curve_fit
+from scipy.signal import savgol_filter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AnalysisOptions:
+    subtract_empty: bool = True
+    cut_beginning: bool = True
+    normalize_to_fid: bool = True
+    normalize_from: float = 70.0
+    normalize_to: float = 90.0
+    long_component: bool = False
+    long_component_from: float = 55.0
+    apodize_time_domain: bool = True
+    apodization_time: float = 100.0
+    adjust_frequency_phase: bool = True
+    adjust_fid_zero: bool = False
+    fid_zero_shift: float = 0.0
+    smooth: bool = False
+    smooth_order: int = 1
+    smooth_window: int = 5
+
+
+@dataclass(frozen=True)
+class SignalAnalysisResult:
+    time_data: np.ndarray
+    signal_data: np.ndarray
+    time_fid: np.ndarray
+    signal_fid: np.ndarray
+    frequency_data: np.ndarray
+    spectrum_data: np.ndarray
+    frequency_fid: np.ndarray
+    spectrum_fid: np.ndarray
+    m2_data: float
+    t2_data: float
+    m2_fid: float
+    t2_fid: float
+
+
+def find_nearest(array: Sequence[float], value: float) -> int:
+    values = np.asarray(array, dtype=float)
+    if values.size == 0:
+        raise ValueError("Cannot find a nearest value in an empty array.")
+    return int(np.abs(values - value).argmin())
+
+
+def gauss(x, amplitude, sigma, y0):
+    return amplitude * np.exp(-(np.asarray(x) ** 2) / (2 * sigma**2)) + y0
+
+
+def gauss_const_ampl(amplitude):
+    return lambda x, sigma, y0: gauss(x, amplitude - y0, sigma, y0)
+
+
+def polynom4(x, amplitude, c, g):
+    x = np.asarray(x)
+    return amplitude + c * x**2 + g * x**4
+
+
+def polynom4_const_ampl(amplitude):
+    return lambda x, c, g: polynom4(x, amplitude, c, g)
+
+
+def polynom6(x, amplitude, c, g, h):
+    x = np.asarray(x)
+    return amplitude + c * x**2 + g * x**4 + h * x**6
+
+
+def polynom6_const_ampl(amplitude):
+    return lambda x, c, g, h: polynom6(x, amplitude, c, g, h)
+
+
+def polynom8(x, amplitude, c, g, h, j):
+    x = np.asarray(x)
+    return amplitude + c * x**2 + g * x**4 + h * x**6 + j * x**8
+
+
+def polynom8_const_ampl(amplitude):
+    return lambda x, c, g, h, j: polynom8(x, amplitude, c, g, h, j)
+
+
+def decaying_exponential(x, a, b, c):
+    return a * np.exp(-np.asarray(x) / b) + c
+
+
+def read_data(file_path: str | Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    data = np.loadtxt(file_path)
+    if data.ndim != 2 or data.shape[1] < 3:
+        raise ValueError(f"{file_path} must contain at least three numeric columns.")
+    return data[:, 0], data[:, 1], data[:, 2]
+
+
+def calculate_frequency_scale(time: Sequence[float]) -> np.ndarray:
+    time = np.asarray(time, dtype=float)
+    if time.size < 2:
+        raise ValueError("At least two time points are required to calculate frequency scale.")
+    numberp = len(time)
+    dt = time[1] - time[0]
+    if dt == 0:
+        raise ValueError("Time step cannot be zero.")
+    f_range = 1 / dt
+    f_nyquist = f_range / 2
+    df = 2 * (f_nyquist / numberp)
+    return np.arange(-f_nyquist, f_nyquist + df, df)[:-1]
+
+
+def calculate_amplitude(real, imaginary):
+    return np.sqrt(np.asarray(real) ** 2 + np.asarray(imaginary) ** 2)
+
+
+def smooth_noisy_signal(signal: Sequence[float], smooth_order: int, smooth_window: int) -> np.ndarray:
+    signal = np.asarray(signal, dtype=float)
+    if signal.size == 0:
+        return signal
+    window = int(smooth_window)
+    order = int(smooth_order)
+    window = max(window, order + 2)
+    if window % 2 == 0:
+        window += 1
+    if window > signal.size:
+        window = signal.size if signal.size % 2 == 1 else signal.size - 1
+    if window <= order or window < 3:
+        logger.warning("Skipping smoothing because window/order are invalid for signal length.")
+        return signal
+    return savgol_filter(signal, window, order)
+
+
+def adjust_phase(real, imaginary):
+    real = np.asarray(real, dtype=float)
+    imaginary = np.asarray(imaginary, dtype=float)
+    delta = np.zeros(360)
+    for phi in range(360):
+        re_phased = real * np.cos(np.deg2rad(phi)) - imaginary * np.sin(np.deg2rad(phi))
+        im_phased = real * np.sin(np.deg2rad(phi)) + imaginary * np.cos(np.deg2rad(phi))
+        magnitude_phased = calculate_amplitude(re_phased, im_phased)
+        delta[phi] = np.mean(magnitude_phased[:5] - re_phased[:5])
+    idx = int(np.argmin(delta))
+    re = real * np.cos(np.deg2rad(idx)) - imaginary * np.sin(np.deg2rad(idx))
+    im = real * np.sin(np.deg2rad(idx)) + imaginary * np.cos(np.deg2rad(idx))
+    return re, im
+
+
+def voigt(x, amp, cen, wid, frac, y0):
+    x = np.asarray(x)
+    lorentzian = amp * (2 * wid) / (np.pi * (4 * (x - cen) ** 2 + wid**2))
+    gaussian = amp * np.exp((-4 * np.log(2) * (x - cen) ** 2) / wid**2) / (
+        wid * np.sqrt(np.pi / (4 * np.log(2)))
+    )
+    return frac * lorentzian + (1 - frac) * gaussian + y0
+
+
+def fit_fft_with_voigh(frequency, fft):
+    frequency = np.asarray(frequency, dtype=float)
+    spectrum = np.abs(fft)
+    idx_peak = int(np.argmax(spectrum))
+    mu0 = frequency[idx_peak]
+    window = (frequency[-1] - frequency[0]) * 0.1
+    mask = (frequency >= (mu0 - window / 2)) & (frequency <= (mu0 + window / 2))
+    x = frequency[mask]
+    y = spectrum[mask]
+    if x.size < 5:
+        raise ValueError("Not enough points to fit FFT with Voigt profile.")
+    p0 = [np.max(spectrum), frequency[idx_peak], (frequency[-1] - frequency[0]) / 50, 0.5, 0]
+    lower = [0, frequency[0], frequency[1] - frequency[0], 0, -10]
+    upper = [np.inf, frequency[-1], frequency[-1] - frequency[0], 1, 10]
+    popt, _ = curve_fit(voigt, x, y, bounds=(lower, upper), p0=p0, maxfev=20000)
+    return popt
+
+
+def adjust_frequency(frequency, real, imaginary):
+    fid_unshifted = np.asarray(real) + 1j * np.asarray(imaginary)
+    fft = np.fft.fftshift(np.fft.fft(fid_unshifted))
+    frequency = np.asarray(frequency, dtype=float)
+    if len(frequency) != len(fft):
+        frequency = np.linspace(frequency[0], frequency[-1], len(fft))
+    try:
+        popt_fitting = fit_fft_with_voigh(frequency, fft)
+        index_max = int(np.argmax(voigt(frequency, *popt_fitting)))
+    except Exception:
+        logger.exception("FFT Voigt fitting failed; using simple maximum for frequency adjustment.")
+        index_max = int(np.argmax(np.abs(fft)))
+    index_zero = find_nearest(frequency, 0)
+    delta_index = index_max - index_zero
+    if delta_index == 0:
+        logger.info("Frequency was not adjusted; maximum is already at zero.")
+        return np.asarray(real), np.asarray(imaginary)
+    fft_shifted = np.concatenate((fft[delta_index:], fft[:delta_index]))
+    fid_shifted = np.fft.ifft(np.fft.ifftshift(fft_shifted))
+    return np.real(fid_shifted), np.imag(fid_shifted)
+
+
+def simple_baseline_correction(fft):
+    fft = np.asarray(fft)
+    n_baseline = max(1, int(round(len(fft) * 0.02)))
+    baseline = np.mean(np.real(fft[:n_baseline]))
+    return np.real(fft - baseline)
+
+
+def apodization_fft(real, freq):
+    real = np.asarray(real, dtype=float)
+    freq = np.asarray(freq, dtype=float)
+    maximum = np.max(np.abs(real))
+    if maximum == 0:
+        return real
+    idx_max = int(np.argmax(np.abs(real)))
+    target = maximum * 0.03
+    relative_idx = int(np.argmin(np.abs(real[idx_max:] - target))) if idx_max < len(real) else 0
+    sigma_ap = abs(freq[min(idx_max + relative_idx, len(freq) - 1)])
+    if sigma_ap == 0:
+        logger.warning("Skipping FFT apodization because sigma is zero.")
+        return real
+    return real * np.exp(-(freq / sigma_ap) ** 2)
+
+
+def add_zeros(time, real, imaginary, number_of_points):
+    time = np.asarray(time, dtype=float)
+    real = np.asarray(real, dtype=float)
+    imaginary = np.asarray(imaginary, dtype=float)
+    length_diff = int(number_of_points) - len(time)
+    if length_diff <= 0:
+        return time, real + 1j * imaginary
+    amount_to_add = np.zeros(length_diff + 1)
+    re_zero = np.concatenate((real, amount_to_add))
+    im_zero = np.concatenate((np.zeros(len(real)), amount_to_add))
+    dt = time[1] - time[0]
+    time_to_add = time[-1] + np.arange(1, length_diff + 1) * dt
+    time_zero = np.concatenate((time, time_to_add))
+    return time_zero, (re_zero + 1j * im_zero)[:-1]
+
+
+def apodization(time, real, imaginary, sigma):
+    time = np.asarray(time, dtype=float)
+    if sigma == 0:
+        return np.asarray(real), np.asarray(imaginary)
+    apodization_function = np.exp(-(time / sigma) ** 4)
+    return np.asarray(real) * apodization_function, np.asarray(imaginary) * apodization_function
+
+
+def cut_beginning(time, data):
+    data = np.asarray(data, dtype=float)
+    time = np.asarray(time, dtype=float)
+    if data.size == 0:
+        return time, data
+    idx = int(np.argmax(data))
+    return time[idx:], data[idx:]
+
+
+def normalize_to_fid(fid, data, time_fid, time_data, start, stop):
+    fid = np.asarray(fid, dtype=float)
+    data = np.asarray(data, dtype=float)
+    mean_fid = np.mean(fid[find_nearest(time_fid, start) : find_nearest(time_fid, stop)])
+    mean_data = np.mean(data[find_nearest(time_data, start) : find_nearest(time_data, stop)])
+    return data - (mean_data - mean_fid)
+
+
+def reference_long_component(time, component, end):
+    time = np.asarray(time, dtype=float)
+    component = np.asarray(component, dtype=float)
+    minimum = find_nearest(time, end)
+    time_range = time[minimum:]
+    component_range = component[minimum:]
+    if len(time_range) < 5:
+        raise ValueError("Not enough long-component points to fit exponential reference.")
+    window = min(41, len(component_range) if len(component_range) % 2 == 1 else len(component_range) - 1)
+    smooth = savgol_filter(component_range, max(window, 3), 0) if window >= 3 else component_range
+    popt, _ = curve_fit(decaying_exponential, time_range, smooth, p0=[5, 30, 0.5], maxfev=20000)
+    return component - decaying_exponential(time, *popt)
+
+
+def calculate_M2(fft_real, frequency):
+    fft_real = np.asarray(fft_real, dtype=float)
+    frequency = np.asarray(frequency, dtype=float)
+    integral = np.trapezoid(np.real(fft_real))
+    if integral == 0:
+        raise ValueError("Cannot calculate M2 because FFT integral is zero.")
+    fur_normalized = np.real(fft_real) / integral
+    multiplication = (frequency**2) * fur_normalized
+    m2 = np.trapezoid(multiplication) * 4 * np.pi**2
+    if np.abs(np.mean(multiplication[:10])) > 10**-6:
+        logger.warning("FFT edge moment is high; apodization may be insufficient.")
+    if m2 < 0:
+        return 0.0, 0.0
+    return float(m2), float(np.sqrt(2 / m2)) if m2 else 0.0
+
+
+def freq_domain_correction(time, real, imaginary=0, apodize=True, time_a=100.0, adjust=True):
+    number_of_points = 2**16
+    imaginary_array = np.zeros_like(np.asarray(real, dtype=float)) if np.isscalar(imaginary) else np.asarray(imaginary)
+    real_array = np.asarray(real, dtype=float)
+    if apodize:
+        real_array, imaginary_array = apodization(time, real_array, imaginary_array, time_a)
+    if adjust:
+        freq = calculate_frequency_scale(time)
+        re_ph, im_ph = adjust_phase(real_array, imaginary_array)
+        real_fft, imaginary_fft = adjust_frequency(freq, re_ph, im_ph)
+    else:
+        fft = np.fft.fftshift(np.fft.fft(real_array + 1j * imaginary_array))
+        real_fft = np.real(fft)
+        imaginary_fft = np.imag(fft)
+    time_zero, fid_zero = add_zeros(time, real_fft, imaginary_fft, number_of_points)
+    frequency = calculate_frequency_scale(time_zero)
+    fft = np.fft.fftshift(np.fft.fft(fid_zero))
+    return frequency, apodization_fft(simple_baseline_correction(fft), frequency)
+
+
+def time_domain_correction(file_path):
+    time, re_original, im_original = read_data(file_path)
+    re_phased, _ = adjust_phase(re_original, im_original)
+    return time, re_phased
+
+
+def nmr_signal_correction(
+    file_path,
+    file_path_fid,
+    file_path_empty=None,
+    file_path_empty_fid=None,
+    options: AnalysisOptions | None = None,
+):
+    options = options or AnalysisOptions()
+    time_td, re_td = time_domain_correction(file_path)
+    time_td_fid, re_td_fid = time_domain_correction(file_path_fid)
+    if options.smooth:
+        re_td = smooth_noisy_signal(re_td, options.smooth_order, options.smooth_window)
+        re_td_fid = smooth_noisy_signal(re_td_fid, options.smooth_order, options.smooth_window)
+    if options.subtract_empty and file_path_empty and file_path_empty_fid:
+        _, re_empty, _ = read_data(file_path_empty)
+        re_td = re_td - re_empty[: len(time_td)]
+        _, re_empty_fid, _ = read_data(file_path_empty_fid)
+        re_td_fid = re_td_fid - re_empty_fid[: len(time_td_fid)]
+    if options.adjust_fid_zero:
+        time_td_fid = time_td_fid + options.fid_zero_shift
+    if options.cut_beginning:
+        _, re_td = cut_beginning(time_td, re_td)
+        time_td = np.linspace(0, 0 + (0.5 * len(re_td)), len(re_td), endpoint=False)
+        time_td_fid, re_td_fid = cut_beginning(time_td_fid, re_td_fid)
+    if options.normalize_to_fid:
+        re_td = normalize_to_fid(
+            re_td_fid, re_td, time_td_fid, time_td, options.normalize_from, options.normalize_to
+        )
+    if options.long_component:
+        re_td = reference_long_component(time_td, re_td, options.long_component_from)
+        re_td_fid = reference_long_component(time_td_fid, re_td_fid, options.long_component_from)
+    return time_td, re_td, time_td_fid, re_td_fid
+
+
+def for_the_sake_of_beauty(time_td, re_td, time_td_fid, re_td_fid, apodize=True, time_a=100.0):
+    if apodize:
+        re_td, _ = apodization(time_td, re_td, 0, time_a)
+        re_td_fid, _ = apodization(time_td_fid, re_td_fid, 0, time_a)
+    return time_td, re_td, time_td_fid, re_td_fid
+
+
+def analyze_signal(data_file, fid_file, data_empty=None, fid_empty=None, options: AnalysisOptions | None = None):
+    options = options or AnalysisOptions()
+    time_td, re_td, time_fid, re_fid = nmr_signal_correction(
+        data_file, fid_file, data_empty, fid_empty, options
+    )
+    time_td, re_td, time_fid, re_fid = for_the_sake_of_beauty(
+        time_td, re_td, time_fid, re_fid, options.apodize_time_domain, options.apodization_time
+    )
+    freq_data, spectrum_data = freq_domain_correction(
+        time_td, re_td, 0, options.apodize_time_domain, options.apodization_time, options.adjust_frequency_phase
+    )
+    freq_fid, spectrum_fid = freq_domain_correction(
+        time_fid, re_fid, 0, options.apodize_time_domain, options.apodization_time, options.adjust_frequency_phase
+    )
+    m2_data, t2_data = calculate_M2(spectrum_data, freq_data)
+    m2_fid, t2_fid = calculate_M2(spectrum_fid, freq_fid)
+    return SignalAnalysisResult(
+        time_td,
+        re_td,
+        time_fid,
+        re_fid,
+        freq_data,
+        spectrum_data,
+        freq_fid,
+        spectrum_fid,
+        round(m2_data, 5),
+        round(t2_data, 5),
+        round(m2_fid, 5),
+        round(t2_fid, 5),
+    )
+
+
+def extract_echo_time(file_path: str | Path) -> float:
+    match = re.search(r".*_\s*(\d+(?:\.\d+)?)_c\.dat$", str(file_path))
+    if not match:
+        raise ValueError("Echo time could not be parsed from file name.")
+    return float(match.group(1))
+
+
+def find_maximum_se(echo_time, maximum, start=0, end=0):
+    echo_time = np.asarray(echo_time, dtype=float)
+    maximum = np.asarray(maximum, dtype=float)
+    if echo_time.size != maximum.size or echo_time.size < 3:
+        raise ValueError("At least three echo-time/maximum pairs are required.")
+    echo_time_to_fit = np.arange(0, echo_time[-1], 0.01)
+    end_idx = None if int(end) == 0 else int(-end)
+    echo_time_cut = echo_time[int(start) : end_idx]
+    maximum_cut = maximum[int(start) : end_idx]
+    popt, _ = curve_fit(gauss, echo_time_cut, maximum_cut, p0=[10, 6, 1], maxfev=20000)
+    return float(gauss(0, *popt)), gauss(echo_time_to_fit, *popt), echo_time_to_fit
+
+
+def build_up_fid(time, data, amplitude, function_to_fit, start, finish):
+    time = np.asarray(time, dtype=float)
+    data = np.asarray(data, dtype=float)
+    start_idx = find_nearest(time, start)
+    finish_idx = find_nearest(time, finish)
+    if finish_idx <= start_idx + 1:
+        raise ValueError("Finish time must be after begin time and include at least two data points.")
+    time_cut = time[start_idx:finish_idx]
+    data_cut = data[start_idx:finish_idx]
+    delta_time = time_cut[1] - time_cut[0]
+    time_build_from_zero = np.arange(0, start, delta_time)
+    if function_to_fit == "Polynom 4":
+        popt, _ = curve_fit(polynom4_const_ampl(amplitude), time_cut, data_cut, p0=[0.005, 0.005])
+        data_built = polynom4(time, amplitude, *popt)
+        data_build_from_zero = polynom4(time_build_from_zero, amplitude, *popt)
+    elif function_to_fit == "Polynom 6":
+        popt, _ = curve_fit(polynom6_const_ampl(amplitude), time_cut, data_cut, p0=[0.005] * 3)
+        data_built = polynom6(time, amplitude, *popt)
+        data_build_from_zero = polynom6(time_build_from_zero, amplitude, *popt)
+    elif function_to_fit == "Polynom 8":
+        popt, _ = curve_fit(polynom8_const_ampl(amplitude), time_cut, data_cut, p0=[0.005] * 4)
+        data_built = polynom8(time, amplitude, *popt)
+        data_build_from_zero = polynom8(time_build_from_zero, amplitude, *popt)
+    elif function_to_fit == "Gaussian":
+        popt, _ = curve_fit(gauss_const_ampl(amplitude), time_cut, data_cut, p0=[8, 0])
+        data_built = gauss(time, amplitude - popt[1], *popt)
+        data_build_from_zero = gauss(time_build_from_zero, amplitude - popt[1], *popt)
+    else:
+        raise ValueError(f"Unsupported build-up function: {function_to_fit}")
+    time_build_middle = time[start_idx + 1 : finish_idx]
+    length = len(time_build_middle)
+    weight = np.linspace(0, 1, length)
+    data_build_middle = weight * data[start_idx + 1 : finish_idx] + (1 - weight) * data_built[start_idx + 1 : finish_idx]
+    time_build_end = time[finish_idx + 1 :]
+    data_build_end = data[finish_idx + 1 :]
+    return (
+        np.concatenate((time_build_from_zero, time_build_middle, time_build_end)),
+        np.concatenate((data_build_from_zero, data_build_middle, data_build_end)),
+        data_built,
+    )
+
+
+def analyze_build_up(time, data, extrapolation, function_to_fit, begin, finish, apodization_time=100.0):
+    time_build, data_build, data_fit = build_up_fid(time, data, extrapolation, function_to_fit, begin, finish)
+    freq_build, spectrum_build = freq_domain_correction(
+        time_build, data_build, 0, True, apodization_time, True
+    )
+    m2_build, t2_build = calculate_M2(spectrum_build, freq_build)
+    return time_build, data_build, data_fit, freq_build, spectrum_build, m2_build, t2_build
+
+
+def time_range_grid(time: Sequence[float], maximum: float):
+    minimum = min(time)
+    start_range = np.arange(minimum, maximum, 0.5)
+    finish_range = np.arange(minimum + 5, maximum + 5, 0.5)
+    return start_range, finish_range

--- a/calculations/recfid_signal.py
+++ b/calculations/recfid_signal.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Sequence
 
 import numpy as np
+from scipy.integrate import trapezoid
 from scipy.optimize import curve_fit
 from scipy.signal import savgol_filter
 
@@ -287,12 +288,12 @@ def reference_long_component(time, component, end):
 def calculate_M2(fft_real, frequency):
     fft_real = np.asarray(fft_real, dtype=float)
     frequency = np.asarray(frequency, dtype=float)
-    integral = np.trapezoid(np.real(fft_real))
+    integral = trapezoid(np.real(fft_real))
     if integral == 0:
         raise ValueError("Cannot calculate M2 because FFT integral is zero.")
     fur_normalized = np.real(fft_real) / integral
     multiplication = (frequency**2) * fur_normalized
-    m2 = np.trapezoid(multiplication) * 4 * np.pi**2
+    m2 = trapezoid(multiplication) * 4 * np.pi**2
     if np.abs(np.mean(multiplication[:10])) > 10**-6:
         logger.warning("FFT edge moment is high; apodization may be insufficient.")
     if m2 < 0:

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -6,3 +6,5 @@ from .dqmq_controller import DQMQTabController
 from .gs_controller import GSTabController
 
 from .general_se_dq_controller import GeneralSEDQController
+
+from .recfid_controller import RecFIDController

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -424,7 +424,7 @@ class RecFIDController(BaseTabController):
             long_component_from=self._value("RecFID_DoubleSpinBox_LongComponentEnd", 55.0),
             apodize_time_domain=self._checked("RecFID_CheckBox_TimeDomainApodization", True),
             apodization_time=self._value("RecFID_DoubleSpinBox_ApodizationSigma", 100.0),
-            adjust_frequency_phase=self._checked("RecFID_CheckBox_AdjustFrequencyPhase", True),
+            adjust_frequency_phase=True,
             adjust_fid_zero=self._checked("RecFID_CheckBox_AdjustZero", False),
             fid_zero_shift=self._value("RecFID_DoubleSpinBox_ZeroShift", 0.0),
             smooth=self._checked("RecFID_CheckBox_Smooth", False),
@@ -535,14 +535,14 @@ class RecFIDController(BaseTabController):
         graph_nmr.plot(
             self.fid_result["Time_td_fid"],
             self.fid_result["Re_td"],
-            pen=mkPen(QColor(0, 0, 0), width=3),
+            pen=mkPen(QColor(255, 0, 0), width=4),
             symbol=None,
         )
         for index, result in enumerate(self.data_results.values()):
             graph_nmr.plot(
                 result["Time_td"],
                 result["Re_td"],
-                pen=mkPen(self._winter_color(index, max(len(self.data_results), 1)), width=2),
+                pen=mkPen(self._winter_color(index, max(len(self.data_results), 1)), width=3),
                 symbol=None,
             )
         # Gradient label is the compact visible color-scale indicator for data curves.
@@ -636,12 +636,12 @@ class RecFIDController(BaseTabController):
         graph_build_fid = getattr(self.ui, "RecFID_PlotWidget_BuildUpNMRSignal", None)
         if graph_build_fid is not None:
             graph_build_fid.clear()
-            graph_build_fid.plot(time_build, data_build, pen=mkPen("b", width=3), symbol=None)
+            graph_build_fid.plot(time_build, data_build, pen=mkPen("b", width=4), symbol=None)
             graph_build_fid.plot(self.fid_result["Time_td_fid"], self.fid_result["Re_td"], pen=mkPen("r", width=3), symbol=None)
         graph_build_fft = getattr(self.ui, "RecFID_PlotWidget_BuildUpSpectra", None)
         if graph_build_fft is not None:
             graph_build_fft.clear()
-            graph_build_fft.plot(freq_build, spectrum_build, pen=mkPen("b", width=3), symbol=None)
+            graph_build_fft.plot(freq_build, spectrum_build, pen=mkPen("b", width=4), symbol=None)
             graph_build_fft.plot(self.fid_result["Freq"], self.fid_result["Real_fft"], pen=mkPen("r", width=3), symbol=None)
 
     def _clear_or_hide(self, widget_name, hide=False):

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -552,7 +552,9 @@ class RecFIDController(BaseTabController):
     def _add_original_signal_gradient_label(self, graph):
         if not self.data_results:
             return
+
         self._clear_original_signal_gradient_label()
+
         scale_text = self._original_signal_color_scale_text()
         html = (
             '<div style="background-color:rgba(255,255,255,210); padding:4px; border:1px solid #444;">'
@@ -564,11 +566,21 @@ class RecFIDController(BaseTabController):
             f' Data winter scale<br>{scale_text}'
             '</div>'
         )
-        label = pg.TextItem(html=html, anchor=(0, 0))
-        graph.addItem(label)
-        x_position, y_position = self._original_signal_label_position()
-        label.setPos(x_position, y_position)
+
+        label = pg.TextItem(html=html, anchor=(1, 0))
+        view_box = graph.getViewBox()
+        label.setParentItem(view_box)
+        label.setZValue(10_000)
+
+        def update_position():
+            rect = view_box.sceneBoundingRect()
+            label.setPos(rect.width() - 10, 10)
+
+        update_position()
+        view_box.sigResized.connect(update_position)
+
         self.original_signal_gradient_label = label
+        self.original_signal_gradient_label_update = update_position
 
     def _original_signal_color_scale_text(self):
         if self.recfid_mode == "se" and self.se_max_result.get("echo_time") is not None:
@@ -578,19 +590,6 @@ class RecFIDController(BaseTabController):
         if len(self.data_results) > 1:
             return f"File order: 1 → {len(self.data_results)}"
         return "Data"
-
-    def _original_signal_label_position(self):
-        x_values = []
-        y_values = []
-        if self.fid_result:
-            x_values.extend(np.asarray(self.fid_result["Time_td_fid"], dtype=float))
-            y_values.extend(np.asarray(self.fid_result["Re_td"], dtype=float))
-        for result in self.data_results.values():
-            x_values.extend(np.asarray(result["Time_td"], dtype=float))
-            y_values.extend(np.asarray(result["Re_td"], dtype=float))
-        if not x_values or not y_values:
-            return 0, 0
-        return float(np.nanmin(x_values)), float(np.nanmax(y_values))
 
     def _clear_original_signal_gradient_label(self):
         label = getattr(self, "original_signal_gradient_label", None)

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 import numpy as np
+import pyqtgraph as pg
 import pyqtgraph.exporters
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
@@ -42,6 +43,7 @@ class RecFIDController(BaseTabController):
         self.extrapolation = None
         self.build_result = {}
         self.time_analysis_result = {}
+        self._clear_original_signal_gradient_label()
         self._close_time_analysis_dialog()
         if clear_plots:
             self.initialize_plots()
@@ -359,6 +361,7 @@ class RecFIDController(BaseTabController):
 
     # Backward-compatible method aliases used by previous controller wiring/tests.
     reset = reset_tab
+    clear_all = reset_tab
     run = run_full_pipeline
     compare = run_basic_data_analysis
     se_analysis = run_se_analysis
@@ -489,18 +492,16 @@ class RecFIDController(BaseTabController):
         divider = self._validated_mse_divider()
         if divider is None:
             return None
-        # In MSE mode the divider represents phase averaging; apply it before
-        # plotting, extrapolation, and build-up so FID and MSE amplitudes share
-        # the same scaled reference frame.
+        # MSE divider applies only to the MSE data amplitude, not the FID reference.
         return recfid.SignalAnalysisResult(
             time_data=result.time_data,
             signal_data=result.signal_data / divider,
             time_fid=result.time_fid,
-            signal_fid=result.signal_fid / divider,
+            signal_fid=result.signal_fid,
             frequency_data=result.frequency_data,
             spectrum_data=result.spectrum_data / divider,
             frequency_fid=result.frequency_fid,
-            spectrum_fid=result.spectrum_fid / divider,
+            spectrum_fid=result.spectrum_fid,
             m2_data=result.m2_data,
             t2_data=result.t2_data,
             m2_fid=result.m2_fid,
@@ -534,7 +535,7 @@ class RecFIDController(BaseTabController):
         graph_nmr.plot(
             self.fid_result["Time_td_fid"],
             self.fid_result["Re_td"],
-            pen=mkPen(QColor(220, 20, 60), width=3),
+            pen=mkPen(QColor(0, 0, 0), width=3),
             symbol=None,
         )
         for index, result in enumerate(self.data_results.values()):
@@ -544,7 +545,63 @@ class RecFIDController(BaseTabController):
                 pen=mkPen(self._winter_color(index, max(len(self.data_results), 1)), width=2),
                 symbol=None,
             )
-        self._status("Original NMR plot: red = FID; data curves use a winter color scale by echo time/file order.")
+        # Gradient label is the compact visible color-scale indicator for data curves.
+        self._add_original_signal_gradient_label(graph_nmr)
+        self._status("Original NMR plot: black = FID; data curves use a winter color scale by echo time/file order.")
+
+    def _add_original_signal_gradient_label(self, graph):
+        if not self.data_results:
+            return
+        self._clear_original_signal_gradient_label()
+        scale_text = self._original_signal_color_scale_text()
+        html = (
+            '<div style="background-color:rgba(255,255,255,210); padding:4px; border:1px solid #444;">'
+            '<span style="color:#000000; font-weight:bold;">FID: black</span><br>'
+            '<span style="color:#0033ff; font-weight:bold;">■</span>'
+            '<span style="color:#007fbf; font-weight:bold;">■</span>'
+            '<span style="color:#00bf80; font-weight:bold;">■</span>'
+            '<span style="color:#00ff7f; font-weight:bold;">■</span>'
+            f' Data winter scale<br>{scale_text}'
+            '</div>'
+        )
+        label = pg.TextItem(html=html, anchor=(0, 0))
+        graph.addItem(label)
+        x_position, y_position = self._original_signal_label_position()
+        label.setPos(x_position, y_position)
+        self.original_signal_gradient_label = label
+
+    def _original_signal_color_scale_text(self):
+        if self.recfid_mode == "se" and self.se_max_result.get("echo_time") is not None:
+            echo_times = np.asarray(self.se_max_result.get("echo_time", []), dtype=float)
+            if echo_times.size > 1 and np.all(np.isfinite(echo_times)):
+                return f"Echo time: {np.min(echo_times):g} → {np.max(echo_times):g}"
+        if len(self.data_results) > 1:
+            return f"File order: 1 → {len(self.data_results)}"
+        return "Data"
+
+    def _original_signal_label_position(self):
+        x_values = []
+        y_values = []
+        if self.fid_result:
+            x_values.extend(np.asarray(self.fid_result["Time_td_fid"], dtype=float))
+            y_values.extend(np.asarray(self.fid_result["Re_td"], dtype=float))
+        for result in self.data_results.values():
+            x_values.extend(np.asarray(result["Time_td"], dtype=float))
+            y_values.extend(np.asarray(result["Re_td"], dtype=float))
+        if not x_values or not y_values:
+            return 0, 0
+        return float(np.nanmin(x_values)), float(np.nanmax(y_values))
+
+    def _clear_original_signal_gradient_label(self):
+        label = getattr(self, "original_signal_gradient_label", None)
+        if label is not None:
+            graph = getattr(self.ui, "RecFID_PlotWidget_OriginalNMRSignal", None)
+            if graph is not None:
+                try:
+                    graph.removeItem(label)
+                except (RuntimeError, ValueError):
+                    logger.debug("RecFID gradient label was already removed", exc_info=True)
+            self.original_signal_gradient_label = None
 
     def _prepare_plot(self, graph):
         graph.clear()
@@ -617,6 +674,8 @@ class RecFIDController(BaseTabController):
         widget = getattr(self.ui, widget_name, None)
         if widget is None:
             return
+        if widget_name == "RecFID_PlotWidget_OriginalNMRSignal":
+            self._clear_original_signal_gradient_label()
         widget.clear()
         legend = getattr(widget.plotItem, "legend", None)
         if legend is not None:

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pyqtgraph.exporters
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+from pyqtgraph import mkPen
+
+from calculations import recfid_signal as recfid
+from controllers.base_tab_controller import BaseTabController
+from dialogs.recfid_dialogs import RecFIDManualEchoTimeDialog, RecFIDTimeAnalysisDialog
+from utils.ui_busy import busy_cursor
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RecFIDState:
+    fid_files: list[str] = field(default_factory=list)
+    data_files: list[str] = field(default_factory=list)
+    fid_empty_files: list[str] = field(default_factory=list)
+    data_empty_files: list[str] = field(default_factory=list)
+    manual_echo_times: list[float] = field(default_factory=list)
+    manual_assignment: bool = False
+    mode: str = "none"
+    fid_result: dict = field(default_factory=dict)
+    data_results: dict = field(default_factory=dict)
+    se_max: np.ndarray = field(default_factory=lambda: np.array([]))
+    se_t2: np.ndarray = field(default_factory=lambda: np.array([]))
+    echo_time_array: np.ndarray = field(default_factory=lambda: np.array([]))
+    extrapolation: float | None = None
+    build_result: dict = field(default_factory=dict)
+
+
+class RecFIDController(BaseTabController):
+    """UI orchestration for the g_RecFID tab."""
+
+    def __init__(self, ui, state, parent=None):
+        super().__init__(ui, state, parent)
+        self.recfid_state = RecFIDState()
+        if not hasattr(self.state, "recfid"):
+            self.state.recfid = self.recfid_state
+
+    def connect_signals(self):
+        self._connect("pushButton", "clicked", lambda: self.select_files("fid"))
+        self._connect("pushButton_2", "clicked", lambda: self.select_files("data"))
+        self._connect("pushButton_3", "clicked", lambda: self.select_files("fid_empty"))
+        self._connect("pushButton_4", "clicked", lambda: self.select_files("data_empty"))
+        self._connect("pushButton_5", "clicked", self.manual_assignment)
+        self._connect("Btn_SaveStatistics", "clicked", self.save_statistics)
+        self._connect("pushButtonExportMaxT2", "clicked", self.exportSEMaxT2)
+        self._connect("pushButtonGO", "clicked", self.run)
+        self._connect("pushButton_analyse", "clicked", self.time_analysis)
+        for widget_name in ("doubleSpinBox_7", "doubleSpinBox_6", "comboBox", "doubleSpinBox_begin", "doubleSpinBox_finish"):
+            signal = "activated" if widget_name == "comboBox" else "valueChanged"
+            self._connect(widget_name, signal, lambda *_args: self.rebuild(show_warning=False))
+
+    def initialize_plots(self):
+        self._setup_graph("widgetOriginalNMRSignal", "Time, μs", "Amplitude", "FID / data")
+        self._setup_graph("widgetSEMax", "Echo Time, μs", "Amplitude", "SE Max")
+        self._setup_graph("widgetBUNMRSignal", "Time, μs", "Amplitude", "FID Build")
+        self._setup_graph("widgetBUFFT", "Frequency, MHz", "Amplitude, a.u", "FFT Build")
+
+    def reset(self):
+        self.recfid_state = RecFIDState()
+        self.state.recfid = self.recfid_state
+        self.initialize_plots()
+
+    def select_files(self, kind):
+        multiple = kind in {"data", "data_empty"}
+        file_mode = QFileDialog.ExistingFiles if multiple else QFileDialog.ExistingFile
+        dialog = QFileDialog(self.parent)
+        dialog.setFileMode(file_mode)
+        dialog.setNameFilter("Data (*.dat *.txt *.csv)")
+        if dialog.exec():
+            files = dialog.selectedFiles()
+        else:
+            return
+        target = {
+            "fid": self.recfid_state.fid_files,
+            "data": self.recfid_state.data_files,
+            "fid_empty": self.recfid_state.fid_empty_files,
+            "data_empty": self.recfid_state.data_empty_files,
+        }[kind]
+        target.clear()
+        target.extend(files)
+        if kind == "data":
+            self._update_mode_from_data_files()
+            self.recfid_state.manual_assignment = False
+            self.recfid_state.manual_echo_times = []
+        self._status(f"Loaded {len(files)} RecFID {kind.replace('_', ' ')} file(s).")
+
+    def run(self):
+        with busy_cursor():
+            if not self._validate_required_files():
+                return
+            try:
+                self.compare()
+                self.extrapolate()
+                begin = self._value("doubleSpinBox_begin", 9.0)
+                finish = self._value("doubleSpinBox_finish", 20.0)
+                self.build_up(begin, finish)
+            except Exception as exc:
+                logger.exception("RecFID analysis failed")
+                self._warn("Couldn't analyse", f"Couldn't analyse the RecFID data because {exc}.")
+
+    def rebuild(self, show_warning=True):
+        if not self.recfid_state.fid_result or not self.recfid_state.data_files:
+            return
+        with busy_cursor():
+            try:
+                self.extrapolate()
+                self.build_up(self._value("doubleSpinBox_begin", 9.0), self._value("doubleSpinBox_finish", 20.0))
+            except Exception as exc:
+                logger.exception("RecFID rebuild failed")
+                if show_warning:
+                    self._warn("Couldn't rebuild", f"Couldn't rebuild the RecFID result because {exc}.")
+
+    def compare(self):
+        data, data_empty, fid, fid_empty = self._choose_files_for_comparison(0)
+        result = recfid.analyze_signal(data, fid, data_empty, fid_empty, self._analysis_options())
+        self.recfid_state.fid_result = {
+            "Time_td_fid": result.time_fid,
+            "Re_td": result.signal_fid,
+            "Freq": result.frequency_fid,
+            "Real_fft": result.spectrum_fid,
+            "M2": result.m2_fid,
+            "T2": result.t2_fid,
+        }
+        graph_nmr = getattr(self.ui, "widgetOriginalNMRSignal", None)
+        if graph_nmr is not None:
+            graph_nmr.clear()
+            graph_nmr.plot(result.time_data, result.signal_data, pen=mkPen("r", width=3), symbol=None)
+            graph_nmr.plot(result.time_fid, result.signal_fid, pen=mkPen("b", width=3), symbol=None)
+        self._status(
+            f"FID T₂*={result.t2_fid}, M₂={result.m2_fid}; data T₂*={result.t2_data}, M₂={result.m2_data}"
+        )
+        return result
+
+    def se_analysis(self, start, finish):
+        state = self.recfid_state
+        state.data_results = {}
+        se_max = []
+        se_t2 = []
+        echo_time = self._echo_times_for_se_files()
+        fid = state.fid_files[0]
+        fid_empty = state.fid_empty_files[0] if state.fid_empty_files and self._checked("checkBox_subempty", True) else None
+        if state.data_empty_files and len(state.data_empty_files) != len(state.data_files):
+            raise ValueError("Please load the same number of data and empty data files.")
+        for idx, file_name in enumerate(state.data_files):
+            data_empty = state.data_empty_files[idx] if state.data_empty_files else None
+            result = recfid.analyze_signal(file_name, fid, data_empty, fid_empty, self._analysis_options())
+            state.data_results[file_name] = {
+                "Time_td": result.time_data,
+                "Re_td": result.signal_data,
+                "Freq": result.frequency_data,
+                "Real_fft": result.spectrum_data,
+                "M2": result.m2_data,
+                "T2": result.t2_data,
+            }
+            se_max.append(float(np.max(result.signal_data)))
+            se_t2.append(result.t2_data)
+        extrapolation, fitting_curve, fittingx = recfid.find_maximum_se(echo_time, se_max, start, finish)
+        state.se_max = np.asarray(se_max, dtype=float)
+        state.se_t2 = np.asarray(se_t2, dtype=float)
+        state.echo_time_array = np.asarray(echo_time, dtype=float)
+        return extrapolation, state.echo_time_array, state.se_max, fittingx, fitting_curve
+
+    def extrapolate(self):
+        state = self.recfid_state
+        graph_se = getattr(self.ui, "widgetSEMax", None)
+        self._update_mode_from_data_files()
+        if state.mode == "se":
+            start = self._value("doubleSpinBox_7", 0.0)
+            end = self._value("doubleSpinBox_6", 0.0)
+            extrapolation, echo_time, maximum_se, fittingx, fittingy = self.se_analysis(start, end)
+            state.extrapolation = extrapolation
+            if graph_se is not None:
+                graph_se.clear()
+                graph_se.show()
+                graph_se.plot([0], [extrapolation], pen="r", symbolPen=None, symbol="o", symbolBrush="r")
+                graph_se.plot(fittingx, fittingy, pen=mkPen("k", width=3, style=Qt.DashLine), symbol=None)
+                graph_se.plot(echo_time, maximum_se, pen=None, symbolPen=None, symbol="o", symbolBrush="b")
+        else:
+            result = self.compare()
+            extrapolation = float(np.max(result.signal_data))
+            if state.mode == "mse":
+                extrapolation /= max(self._value("doubleSpinBox_8", 2.0), 1.0)
+            state.extrapolation = extrapolation
+            state.se_max = np.array([float(np.max(result.signal_data))])
+            state.se_t2 = np.array([result.t2_data])
+            state.echo_time_array = np.array([0.0])
+            state.data_results[state.mode.upper()] = {
+                "Time_td": result.time_data,
+                "Re_td": result.signal_data,
+                "Freq": result.frequency_data,
+                "Real_fft": result.spectrum_data,
+                "M2": result.m2_data,
+                "T2": result.t2_data,
+            }
+            if graph_se is not None:
+                graph_se.clear()
+                graph_se.hide()
+        self._status(f"RecFID max = {round(state.extrapolation, 2)}")
+        return state.extrapolation
+
+    def build_up(self, begin, finish):
+        state = self.recfid_state
+        if state.extrapolation is None:
+            raise ValueError("Run extrapolation before build-up.")
+        fid = state.fid_result
+        if not fid:
+            raise ValueError("Run FID/data analysis before build-up.")
+        time_build, data_build, data_fit, freq_build, spectrum_build, m2_build, t2_build = recfid.analyze_build_up(
+            fid["Time_td_fid"],
+            fid["Re_td"],
+            state.extrapolation,
+            self._text("comboBox", "Gaussian"),
+            begin,
+            finish,
+            self._value("doubleSpinBox_5", 100.0),
+        )
+        state.build_result = {
+            "Time": time_build,
+            "Re": data_build,
+            "Fit": data_fit,
+            "Freq": freq_build,
+            "Real_fft": spectrum_build,
+            "M2": float(m2_build),
+            "T2": float(t2_build),
+        }
+        graph_build_fid = getattr(self.ui, "widgetBUNMRSignal", None)
+        if graph_build_fid is not None:
+            graph_build_fid.clear()
+            graph_build_fid.plot(time_build, data_build, pen=mkPen("b", width=3), symbol=None)
+            graph_build_fid.plot(fid["Time_td_fid"], fid["Re_td"], pen=mkPen("r", width=3), symbol=None)
+        graph_build_fft = getattr(self.ui, "widgetBUFFT", None)
+        if graph_build_fft is not None:
+            graph_build_fft.clear()
+            graph_build_fft.plot(freq_build, spectrum_build, pen=mkPen("b", width=3), symbol=None)
+            graph_build_fft.plot(fid["Freq"], fid["Real_fft"], pen=mkPen("r", width=3), symbol=None)
+        self._status(
+            f"Build-up T₂*={round(t2_build, 5)}, M₂={round(m2_build, 5)}; FID T₂*={fid['T2']}, M₂={fid['M2']}"
+        )
+        return m2_build, t2_build
+
+    def manual_assignment(self):
+        if not self.recfid_state.data_files:
+            self._warn("No SE files", "Load (M)SE files before assigning echo times manually.")
+            return
+        dialog = RecFIDManualEchoTimeDialog(
+            self.recfid_state.data_files, self.recfid_state.manual_echo_times, self.parent
+        )
+        if dialog.exec():
+            try:
+                self.recfid_state.manual_echo_times = dialog.echo_times()
+                self.recfid_state.manual_assignment = True
+            except ValueError as exc:
+                self._warn("Invalid echo time", str(exc))
+
+    def time_analysis(self):
+        if not self.recfid_state.fid_result:
+            self._warn("No build-up data", "Run RecFID analysis before analysing time ranges.")
+            return
+        with busy_cursor():
+            start_range, finish_range, m2_values, t2_values = self._calculate_time_analysis(self._text("comboBox", "Gaussian"))
+        dialog = RecFIDTimeAnalysisDialog(self.parent)
+        dialog.plot_data(start_range, finish_range, t2_values, m2_values)
+        dialog.setWindowTitle("RecFID T2 Map")
+        dialog.resize(800, 600)
+        dialog.show()
+        self._plot_window = dialog
+
+    def save_statistics(self):
+        if not self.recfid_state.fid_result:
+            self._warn("No build-up data", "Run RecFID analysis before exporting a T2 map.")
+            return
+        file_path, _ = QFileDialog.getSaveFileName(
+            self.parent,
+            "Save Frequency and T2 Data",
+            "statistical_analysis.txt",
+            "Text Files (*.txt);;All Files (*)",
+            options=QFileDialog.DontConfirmOverwrite,
+        )
+        if not file_path:
+            return
+        with busy_cursor():
+            for index in range(getattr(self.ui, "comboBox").count()):
+                self.ui.comboBox.setCurrentIndex(index)
+                start_range, finish_range, _m2, t2 = self._calculate_time_analysis(self.ui.comboBox.currentText())
+                ranges = [(begin, finish) for begin in start_range for finish in finish_range]
+                self._write_frequencies_t2(ranges, t2.flatten(), file_path, self.ui.comboBox.currentText())
+        self._status(f"Saved RecFID statistics to {file_path}")
+
+    def exportSEMaxT2(self):
+        state = self.recfid_state
+        if state.extrapolation is None or state.se_max.size == 0:
+            self._warn("No SE maxima", "Run RecFID analysis before exporting SE maxima and T2 values.")
+            return
+        file_path, _ = QFileDialog.getSaveFileName(
+            self.parent,
+            "Save Max Amplitudes of SE and T2*",
+            "MaxSeT2.txt",
+            "Text Files (*.txt);;All Files (*)",
+            options=QFileDialog.DontConfirmOverwrite,
+        )
+        if not file_path:
+            return
+        with open(file_path, "a", encoding="utf-8") as handle:
+            handle.write(f"Max Extrapolation: {state.extrapolation}\n")
+            handle.write("Echo Time\tT2\tRatio\tEcho Amp\n")
+            for echo_time, maximum, t2 in zip(state.echo_time_array, state.se_max, state.se_t2):
+                ratio = state.extrapolation / maximum if maximum else 0
+                handle.write(f"{echo_time}\t{t2}\t{ratio}\t{maximum}\t\n")
+            handle.write("\n")
+        self._status(f"Saved RecFID SE maxima and T2 values to {file_path}")
+
+    def save_results(self):
+        if not self.recfid_state.build_result:
+            self._warn("No RecFID result", "Run RecFID analysis before saving reconstructed FID results.")
+            return
+        directory = QFileDialog.getExistingDirectory(self.parent, "Select RecFID export directory")
+        if not directory:
+            return
+        base = Path(directory)
+        build = self.recfid_state.build_result
+        np.savetxt(base / "recfid_built_fid.csv", np.column_stack((build["Time"], build["Re"])), delimiter=",", header="Time,Re", comments="")
+        np.savetxt(base / "recfid_built_fft.csv", np.column_stack((build["Freq"], build["Real_fft"])), delimiter=",", header="Frequency,Amplitude", comments="")
+        for widget_name, file_name in (("widgetBUNMRSignal", "recfid_built_fid.png"), ("widgetBUFFT", "recfid_built_fft.png")):
+            widget = getattr(self.ui, widget_name, None)
+            if widget is not None:
+                exporter = pyqtgraph.exporters.ImageExporter(widget.plotItem)
+                exporter.export(str(base / file_name))
+        self._status(f"Saved RecFID results to {directory}")
+
+    def _calculate_time_analysis(self, function_name):
+        fid = self.recfid_state.fid_result
+        start_range, finish_range = recfid.time_range_grid(fid["Time_td_fid"], self._value("spinBoxTimeRange", 24))
+        m2 = []
+        t2 = []
+        for begin in start_range:
+            for finish in finish_range:
+                if finish < begin + 3:
+                    m2_build = 0
+                    t2_build = 0
+                else:
+                    try:
+                        _tb, _db, _df, freq, spectrum, m2_build, t2_build = recfid.analyze_build_up(
+                            fid["Time_td_fid"], fid["Re_td"], self.recfid_state.extrapolation, function_name, begin, finish, self._value("doubleSpinBox_5", 100.0)
+                        )
+                    except Exception:
+                        logger.exception("RecFID time-analysis point failed: begin=%s finish=%s", begin, finish)
+                        m2_build = 0
+                        t2_build = 0
+                m2.append(m2_build)
+                t2.append(t2_build)
+        return (
+            start_range,
+            finish_range,
+            np.asarray(m2).reshape(len(start_range), len(finish_range)),
+            np.asarray(t2).reshape(len(start_range), len(finish_range)),
+        )
+
+    def _write_frequencies_t2(self, ranges, t2s, file_path, function_name):
+        with open(file_path, "a", encoding="utf-8") as handle:
+            handle.write(f"Name: {self.recfid_state.fid_files}\n")
+            handle.write(f"Mode: {self.recfid_state.mode}\n")
+            handle.write(f"Function: {function_name}\n\n")
+            for range_bf, t2 in zip(ranges, t2s):
+                handle.write(f"{range_bf[0]}\t{range_bf[1]}\t{t2}\t\n")
+            handle.write("\n")
+
+    def _analysis_options(self):
+        return recfid.AnalysisOptions(
+            subtract_empty=self._checked("checkBox_subempty", True),
+            cut_beginning=self._checked("checkBox_cutbegin", True),
+            normalize_to_fid=self._checked("checkBox_normtofid", True),
+            normalize_from=self._value("doubleSpinBox", 70.0),
+            normalize_to=self._value("doubleSpinBox_2", 90.0),
+            long_component=self._checked("checkBox_longcomp", False),
+            long_component_from=self._value("doubleSpinBox_4", 55.0),
+            apodize_time_domain=self._checked("checkBox_td_apodization", True),
+            apodization_time=self._value("doubleSpinBox_5", 100.0),
+            adjust_frequency_phase=True,
+            adjust_fid_zero=self._checked("checkBox_adjust_zero", False),
+            fid_zero_shift=self._value("doubleSpinBox_3", 0.0),
+            smooth=self._checked("checkBoxSmooth", False),
+            smooth_order=int(self._value("spinBoxOrder", 1)),
+            smooth_window=int(self._value("spinBoxWindow", 5)),
+        )
+
+    def _choose_files_for_comparison(self, number):
+        state = self.recfid_state
+        if state.mode == "se":
+            data = state.data_files[number]
+            data_empty = state.data_empty_files[number] if state.data_empty_files else None
+        else:
+            data = state.data_files[0]
+            data_empty = state.data_empty_files[0] if state.data_empty_files else None
+        return data, data_empty, state.fid_files[0], state.fid_empty_files[0] if state.fid_empty_files else None
+
+    def _echo_times_for_se_files(self):
+        state = self.recfid_state
+        if state.manual_assignment:
+            return state.manual_echo_times
+        echo_time = []
+        try:
+            for file_name in state.data_files:
+                echo_time.append(recfid.extract_echo_time(file_name))
+        except ValueError:
+            self.manual_assignment()
+            if not state.manual_assignment:
+                raise
+            echo_time = state.manual_echo_times
+        return echo_time
+
+    def _update_mode_from_data_files(self):
+        count = len(self.recfid_state.data_files)
+        if count > 4:
+            self.recfid_state.mode = "se"
+        elif count == 1:
+            self.recfid_state.mode = "mse"
+        elif count > 1:
+            self.recfid_state.mode = "single_se"
+        else:
+            self.recfid_state.mode = "none"
+
+    def _validate_required_files(self):
+        if not self.recfid_state.fid_files:
+            self._warn("No FID file", "Load a FID file first.")
+            return False
+        if not self.recfid_state.data_files:
+            self._warn("No (M)SE file", "Load (M)SE data first.")
+            return False
+        return True
+
+    def _connect(self, widget_name, signal_name, slot):
+        widget = getattr(self.ui, widget_name, None)
+        if widget is None:
+            logger.warning("RecFID widget %s is missing; signal not connected", widget_name)
+            return
+        signal = getattr(widget, signal_name, None)
+        if signal is None:
+            logger.warning("RecFID widget %s has no %s signal", widget_name, signal_name)
+            return
+        signal.connect(slot)
+
+    def _setup_graph(self, widget_name, xlabel, ylabel, title):
+        widget = getattr(self.ui, widget_name, None)
+        if widget is None:
+            return
+        widget.clear()
+        widget.getAxis("left").setLabel(ylabel)
+        widget.getAxis("bottom").setLabel(xlabel)
+        widget.setTitle(title)
+
+    def _checked(self, widget_name, default=False):
+        widget = getattr(self.ui, widget_name, None)
+        return widget.isChecked() if widget is not None else default
+
+    def _value(self, widget_name, default=0.0):
+        widget = getattr(self.ui, widget_name, None)
+        return widget.value() if widget is not None else default
+
+    def _text(self, widget_name, default=""):
+        widget = getattr(self.ui, widget_name, None)
+        return widget.currentText() if widget is not None else default
+
+    def _warn(self, title, message):
+        QMessageBox.warning(self.parent, title, message, QMessageBox.Ok)
+
+    def _status(self, message):
+        if self.parent is not None and hasattr(self.parent, "statusBar"):
+            self.parent.statusBar().showMessage(message, 8000)
+        logger.info(message)

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -6,12 +6,14 @@ from pathlib import Path
 import numpy as np
 import pyqtgraph.exporters
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QFileDialog, QMessageBox
 from pyqtgraph import mkPen
 
 from calculations import recfid_signal as recfid
 from controllers.base_tab_controller import BaseTabController
-from dialogs.recfid_dialogs import RecFIDManualEchoTimeDialog, RecFIDTimeAnalysisDialog
+from dialogs.recfid_dialogs import RecFIDTimeAnalysisDialog
+from dialogs.recfid_echo_time_dialog import RecFIDEchoTimeDialog
 from utils.ui_busy import busy_cursor
 
 logger = logging.getLogger(__name__)
@@ -54,12 +56,12 @@ class RecFIDController(BaseTabController):
         for widget_name in (
             "RecFID_DoubleSpinBox_SEFitFrom",
             "RecFID_DoubleSpinBox_SEFitTo",
-            "RecFID_ComboBox_BuildFunction",
             "RecFID_DoubleSpinBox_BuildFrom",
             "RecFID_DoubleSpinBox_BuildTo",
+            "RecFID_DoubleSpinBox_MseDivider",
         ):
-            signal = "activated" if widget_name == "RecFID_ComboBox_BuildFunction" else "valueChanged"
-            self._connect(widget_name, signal, lambda *_args: self.rebuild(show_warning=False))
+            self._connect(widget_name, "editingFinished", lambda *_args: self.rebuild(show_warning=False))
+        self._connect("RecFID_ComboBox_BuildFunction", "activated", lambda *_args: self.rebuild(show_warning=False))
 
     def initialize_plots(self):
         self._setup_graph("RecFID_PlotWidget_OriginalNMRSignal", "Time, μs", "Amplitude", "FID / data")
@@ -105,7 +107,8 @@ class RecFIDController(BaseTabController):
                 return
             try:
                 self.run_basic_data_analysis()
-                self.extrapolate()
+                if self.extrapolate() is None:
+                    return
                 self.build_up()
             except Exception as exc:
                 logger.exception("RecFID analysis failed")
@@ -116,7 +119,8 @@ class RecFIDController(BaseTabController):
             return
         with busy_cursor():
             try:
-                self.extrapolate()
+                if self.extrapolate() is None:
+                    return
                 self.build_up()
             except Exception as exc:
                 logger.exception("RecFID rebuild failed")
@@ -134,7 +138,10 @@ class RecFIDController(BaseTabController):
             "M2": result.m2_fid,
             "T2": result.t2_fid,
         }
-        self._plot_original_analysis(result)
+        self.data_results = {
+            data: self._data_result_from_analysis(result),
+        }
+        self._plot_all_processed_signals()
         self._status(
             f"FID T₂*={result.t2_fid}, M₂={result.m2_fid}; data T₂*={result.t2_data}, M₂={result.m2_data}"
         )
@@ -151,14 +158,7 @@ class RecFIDController(BaseTabController):
         for index, file_name in enumerate(self.selected_data_files):
             data_empty = self.selected_data_empty_files[index] if self.selected_data_empty_files else None
             result = recfid.analyze_signal(file_name, fid, data_empty, fid_empty, self._analysis_options())
-            self.data_results[file_name] = {
-                "Time_td": result.time_data,
-                "Re_td": result.signal_data,
-                "Freq": result.frequency_data,
-                "Real_fft": result.spectrum_data,
-                "M2": result.m2_data,
-                "T2": result.t2_data,
-            }
+            self.data_results[file_name] = self._data_result_from_analysis(result)
             se_max.append(float(np.max(result.signal_data)))
             se_t2.append(result.t2_data)
 
@@ -175,6 +175,7 @@ class RecFIDController(BaseTabController):
             "fit_x": fittingx,
             "fit_y": fitting_curve,
         }
+        self._plot_all_processed_signals()
         return extrapolation
 
     def extrapolate(self):
@@ -185,7 +186,12 @@ class RecFIDController(BaseTabController):
         elif self.recfid_mode == "mse":
             result = self.run_basic_data_analysis()
             raw_maximum = float(np.max(result.signal_data))
-            divider = max(self._value("RecFID_DoubleSpinBox_MseDivider", 2.0), 1.0)
+            divider = self._validated_mse_divider()
+            if divider is None:
+                self.extrapolation = None
+                self.se_max_result = {}
+                self.build_result = {}
+                return None
             self.extrapolation = raw_maximum / divider
             self.se_max_result = {
                 "echo_time": np.array([0.0]),
@@ -298,7 +304,7 @@ class RecFIDController(BaseTabController):
         if not self.selected_data_files:
             self._warn("No SE files", "Load (M)SE files before assigning echo times manually.")
             return
-        dialog = RecFIDManualEchoTimeDialog(self.selected_data_files, self.echo_time_values, self.parent)
+        dialog = RecFIDEchoTimeDialog(self.selected_data_files, self.echo_time_values, self.parent)
         if dialog.exec():
             try:
                 self.echo_time_values = dialog.echo_times()
@@ -428,6 +434,10 @@ class RecFIDController(BaseTabController):
             for file_name in self.selected_data_files:
                 echo_times.append(recfid.extract_echo_time(file_name))
         except ValueError:
+            self._warn(
+                "Could not parse echo time",
+                "Could not parse echo time from filenames. Please enter echo times manually.",
+            )
             self.open_manual_echo_time_dialog()
             if not self.manual_echo_time_enabled:
                 raise
@@ -459,19 +469,82 @@ class RecFIDController(BaseTabController):
         self.selected_data_empty_files = []
         return True
 
-    def _plot_original_analysis(self, result):
+    def _data_result_from_analysis(self, result):
+        return {
+            "Time_td": result.time_data,
+            "Re_td": result.signal_data,
+            "Freq": result.frequency_data,
+            "Real_fft": result.spectrum_data,
+            "M2": result.m2_data,
+            "T2": result.t2_data,
+        }
+
+    def _validated_mse_divider(self):
+        divider = self._value("RecFID_DoubleSpinBox_MseDivider", 2.0)
+        if not np.isfinite(divider) or divider <= 0:
+            self._warn("Invalid MSE divider", "MSE divider must be greater than zero.")
+            return None
+        return divider
+
+    def _plot_all_processed_signals(self):
+        if not self.fid_result:
+            return
         graph_nmr = getattr(self.ui, "RecFID_PlotWidget_OriginalNMRSignal", None)
         if graph_nmr is not None:
-            graph_nmr.clear()
-            graph_nmr.show()
-            graph_nmr.plot(result.time_data, result.signal_data, pen=mkPen("r", width=3), symbol=None)
-            graph_nmr.plot(result.time_fid, result.signal_fid, pen=mkPen("b", width=3), symbol=None)
+            self._prepare_plot_with_legend(graph_nmr)
+            fid_label = f"FID: {Path(self.selected_fid_files[0]).name}" if self.selected_fid_files else "FID"
+            graph_nmr.plot(
+                self.fid_result["Time_td_fid"],
+                self.fid_result["Re_td"],
+                pen=mkPen(QColor(220, 20, 60), width=3),
+                symbol=None,
+                name=fid_label,
+            )
+            for index, (file_path, result) in enumerate(self.data_results.items()):
+                color = self._winter_color(index, max(len(self.data_results), 1))
+                graph_nmr.plot(
+                    result["Time_td"],
+                    result["Re_td"],
+                    pen=mkPen(color, width=2),
+                    symbol=None,
+                    name=f"Data {index + 1}: {Path(file_path).name}",
+                )
+
         graph_fft = getattr(self.ui, "RecFID_PlotWidget_OriginalSpectra", None)
         if graph_fft is not None:
-            graph_fft.clear()
-            graph_fft.show()
-            graph_fft.plot(result.frequency_data, result.spectrum_data, pen=mkPen("r", width=3), symbol=None)
-            graph_fft.plot(result.frequency_fid, result.spectrum_fid, pen=mkPen("b", width=3), symbol=None)
+            self._prepare_plot_with_legend(graph_fft)
+            fid_label = f"FID: {Path(self.selected_fid_files[0]).name}" if self.selected_fid_files else "FID"
+            graph_fft.plot(
+                self.fid_result["Freq"],
+                self.fid_result["Real_fft"],
+                pen=mkPen(QColor(220, 20, 60), width=3),
+                symbol=None,
+                name=fid_label,
+            )
+            for index, (file_path, result) in enumerate(self.data_results.items()):
+                color = self._winter_color(index, max(len(self.data_results), 1))
+                graph_fft.plot(
+                    result["Freq"],
+                    result["Real_fft"],
+                    pen=mkPen(color, width=2),
+                    symbol=None,
+                    name=f"Data {index + 1}: {Path(file_path).name}",
+                )
+
+    def _prepare_plot_with_legend(self, graph):
+        graph.clear()
+        graph.show()
+        legend = getattr(graph.plotItem, "legend", None)
+        if legend is None:
+            graph.addLegend()
+        else:
+            legend.clear()
+
+    def _winter_color(self, index, total):
+        fraction = 0.0 if total <= 1 else index / (total - 1)
+        green = int(round(255 * fraction))
+        blue = int(round(255 * (1 - 0.5 * fraction)))
+        return QColor(0, green, blue)
 
     def _plot_se_maximum(self):
         graph = getattr(self.ui, "RecFID_PlotWidget_SEMax", None)

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
@@ -18,112 +17,116 @@ from utils.ui_busy import busy_cursor
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class RecFIDState:
-    fid_files: list[str] = field(default_factory=list)
-    data_files: list[str] = field(default_factory=list)
-    fid_empty_files: list[str] = field(default_factory=list)
-    data_empty_files: list[str] = field(default_factory=list)
-    manual_echo_times: list[float] = field(default_factory=list)
-    manual_assignment: bool = False
-    mode: str = "none"
-    fid_result: dict = field(default_factory=dict)
-    data_results: dict = field(default_factory=dict)
-    se_max: np.ndarray = field(default_factory=lambda: np.array([]))
-    se_t2: np.ndarray = field(default_factory=lambda: np.array([]))
-    echo_time_array: np.ndarray = field(default_factory=lambda: np.array([]))
-    extrapolation: float | None = None
-    build_result: dict = field(default_factory=dict)
-
-
 class RecFIDController(BaseTabController):
     """UI orchestration for the g_RecFID tab."""
 
     def __init__(self, ui, state, parent=None):
         super().__init__(ui, state, parent)
-        self.recfid_state = RecFIDState()
-        if not hasattr(self.state, "recfid"):
-            self.state.recfid = self.recfid_state
+        self.reset_tab(clear_plots=False)
+
+    def reset_tab(self, clear_plots=True):
+        self.recfid_mode = "none"
+        self.selected_fid_files = []
+        self.selected_data_files = []
+        self.selected_fid_empty_files = []
+        self.selected_data_empty_files = []
+        self.echo_time_values = []
+        self.manual_echo_time_enabled = False
+        self.fid_result = {}
+        self.data_results = {}
+        self.se_max_result = {}
+        self.extrapolation = None
+        self.build_result = {}
+        if clear_plots:
+            self.initialize_plots()
 
     def connect_signals(self):
-        self._connect("pushButton", "clicked", lambda: self.select_files("fid"))
-        self._connect("pushButton_2", "clicked", lambda: self.select_files("data"))
-        self._connect("pushButton_3", "clicked", lambda: self.select_files("fid_empty"))
-        self._connect("pushButton_4", "clicked", lambda: self.select_files("data_empty"))
-        self._connect("pushButton_5", "clicked", self.manual_assignment)
-        self._connect("Btn_SaveStatistics", "clicked", self.save_statistics)
-        self._connect("pushButtonExportMaxT2", "clicked", self.exportSEMaxT2)
-        self._connect("pushButtonGO", "clicked", self.run)
-        self._connect("pushButton_analyse", "clicked", self.time_analysis)
-        for widget_name in ("doubleSpinBox_7", "doubleSpinBox_6", "comboBox", "doubleSpinBox_begin", "doubleSpinBox_finish"):
-            signal = "activated" if widget_name == "comboBox" else "valueChanged"
+        self._connect("RecFID_Button_LoadFID", "clicked", self.load_fid_files)
+        self._connect("RecFID_Button_LoadData", "clicked", self.load_data_files)
+        self._connect("RecFID_Button_LoadFIDEmpty", "clicked", self.load_empty_fid_files)
+        self._connect("RecFID_Button_LoadDataEmpty", "clicked", self.load_empty_data_files)
+        self._connect("RecFID_Button_Clear", "clicked", self.reset_tab)
+        self._connect("RecFID_Button_ManualEchoTimes", "clicked", self.open_manual_echo_time_dialog)
+        self._connect("RecFID_Button_SaveStatistics", "clicked", self.save_statistics)
+        self._connect("RecFID_Button_ExportSEMaxT2", "clicked", self.export_se_max_t2)
+        self._connect("RecFID_Button_Run", "clicked", self.run_full_pipeline)
+        self._connect("RecFID_Button_TimeAnalysis", "clicked", self.run_time_analysis)
+        for widget_name in (
+            "RecFID_DoubleSpinBox_SEFitFrom",
+            "RecFID_DoubleSpinBox_SEFitTo",
+            "RecFID_ComboBox_BuildFunction",
+            "RecFID_DoubleSpinBox_BuildFrom",
+            "RecFID_DoubleSpinBox_BuildTo",
+        ):
+            signal = "activated" if widget_name == "RecFID_ComboBox_BuildFunction" else "valueChanged"
             self._connect(widget_name, signal, lambda *_args: self.rebuild(show_warning=False))
 
     def initialize_plots(self):
-        self._setup_graph("widgetOriginalNMRSignal", "Time, μs", "Amplitude", "FID / data")
-        self._setup_graph("widgetSEMax", "Echo Time, μs", "Amplitude", "SE Max")
-        self._setup_graph("widgetBUNMRSignal", "Time, μs", "Amplitude", "FID Build")
-        self._setup_graph("widgetBUFFT", "Frequency, MHz", "Amplitude, a.u", "FFT Build")
+        self._setup_graph("RecFID_PlotWidget_OriginalNMRSignal", "Time, μs", "Amplitude", "FID / data")
+        self._setup_graph("RecFID_PlotWidget_OriginalSpectra", "Frequency, MHz", "Amplitude, a.u", "FFT")
+        self._setup_graph("RecFID_PlotWidget_SEMax", "Echo Time, μs", "Amplitude", "SE Max")
+        self._setup_graph("RecFID_PlotWidget_BuildUpNMRSignal", "Time, μs", "Amplitude", "FID Build")
+        self._setup_graph("RecFID_PlotWidget_BuildUpSpectra", "Frequency, MHz", "Amplitude, a.u", "FFT Build")
 
-    def reset(self):
-        self.recfid_state = RecFIDState()
-        self.state.recfid = self.recfid_state
-        self.initialize_plots()
-
-    def select_files(self, kind):
-        multiple = kind in {"data", "data_empty"}
-        file_mode = QFileDialog.ExistingFiles if multiple else QFileDialog.ExistingFile
-        dialog = QFileDialog(self.parent)
-        dialog.setFileMode(file_mode)
-        dialog.setNameFilter("Data (*.dat *.txt *.csv)")
-        if dialog.exec():
-            files = dialog.selectedFiles()
-        else:
+    def load_fid_files(self):
+        files = self._select_files(multiple=False)
+        if files is None:
             return
-        target = {
-            "fid": self.recfid_state.fid_files,
-            "data": self.recfid_state.data_files,
-            "fid_empty": self.recfid_state.fid_empty_files,
-            "data_empty": self.recfid_state.data_empty_files,
-        }[kind]
-        target.clear()
-        target.extend(files)
-        if kind == "data":
-            self._update_mode_from_data_files()
-            self.recfid_state.manual_assignment = False
-            self.recfid_state.manual_echo_times = []
-        self._status(f"Loaded {len(files)} RecFID {kind.replace('_', ' ')} file(s).")
+        self.selected_fid_files = files
+        self._status(f"Loaded {len(files)} RecFID FID file(s).")
 
-    def run(self):
+    def load_data_files(self):
+        files = self._select_files(multiple=True)
+        if files is None:
+            return
+        self.selected_data_files = files
+        self.recfid_mode = "mse" if len(files) == 1 else "se" if len(files) > 1 else "none"
+        self.echo_time_values = []
+        self.manual_echo_time_enabled = False
+        self._status(f"Loaded {len(files)} RecFID data file(s); mode={self.recfid_mode}.")
+
+    def load_empty_fid_files(self):
+        files = self._select_files(multiple=False)
+        if files is None:
+            return
+        self.selected_fid_empty_files = files
+        self._status(f"Loaded {len(files)} RecFID empty FID file(s).")
+
+    def load_empty_data_files(self):
+        files = self._select_files(multiple=True)
+        if files is None:
+            return
+        self.selected_data_empty_files = files
+        self._status(f"Loaded {len(files)} RecFID empty data file(s).")
+
+    def run_full_pipeline(self):
         with busy_cursor():
-            if not self._validate_required_files():
+            if not self._validate_required_files() or not self._validate_empty_data_files():
                 return
             try:
-                self.compare()
+                self.run_basic_data_analysis()
                 self.extrapolate()
-                begin = self._value("doubleSpinBox_begin", 9.0)
-                finish = self._value("doubleSpinBox_finish", 20.0)
-                self.build_up(begin, finish)
+                self.build_up()
             except Exception as exc:
                 logger.exception("RecFID analysis failed")
                 self._warn("Couldn't analyse", f"Couldn't analyse the RecFID data because {exc}.")
 
     def rebuild(self, show_warning=True):
-        if not self.recfid_state.fid_result or not self.recfid_state.data_files:
+        if not self.fid_result or not self.selected_data_files:
             return
         with busy_cursor():
             try:
                 self.extrapolate()
-                self.build_up(self._value("doubleSpinBox_begin", 9.0), self._value("doubleSpinBox_finish", 20.0))
+                self.build_up()
             except Exception as exc:
                 logger.exception("RecFID rebuild failed")
                 if show_warning:
                     self._warn("Couldn't rebuild", f"Couldn't rebuild the RecFID result because {exc}.")
 
-    def compare(self):
+    def run_basic_data_analysis(self):
         data, data_empty, fid, fid_empty = self._choose_files_for_comparison(0)
         result = recfid.analyze_signal(data, fid, data_empty, fid_empty, self._analysis_options())
-        self.recfid_state.fid_result = {
+        self.fid_result = {
             "Time_td_fid": result.time_fid,
             "Re_td": result.signal_fid,
             "Freq": result.frequency_fid,
@@ -131,30 +134,24 @@ class RecFIDController(BaseTabController):
             "M2": result.m2_fid,
             "T2": result.t2_fid,
         }
-        graph_nmr = getattr(self.ui, "widgetOriginalNMRSignal", None)
-        if graph_nmr is not None:
-            graph_nmr.clear()
-            graph_nmr.plot(result.time_data, result.signal_data, pen=mkPen("r", width=3), symbol=None)
-            graph_nmr.plot(result.time_fid, result.signal_fid, pen=mkPen("b", width=3), symbol=None)
+        self._plot_original_analysis(result)
         self._status(
             f"FID T₂*={result.t2_fid}, M₂={result.m2_fid}; data T₂*={result.t2_data}, M₂={result.m2_data}"
         )
         return result
 
-    def se_analysis(self, start, finish):
-        state = self.recfid_state
-        state.data_results = {}
+    def run_se_analysis(self):
+        self.data_results = {}
         se_max = []
         se_t2 = []
         echo_time = self._echo_times_for_se_files()
-        fid = state.fid_files[0]
-        fid_empty = state.fid_empty_files[0] if state.fid_empty_files and self._checked("checkBox_subempty", True) else None
-        if state.data_empty_files and len(state.data_empty_files) != len(state.data_files):
-            raise ValueError("Please load the same number of data and empty data files.")
-        for idx, file_name in enumerate(state.data_files):
-            data_empty = state.data_empty_files[idx] if state.data_empty_files else None
+        fid = self.selected_fid_files[0]
+        fid_empty = self.selected_fid_empty_files[0] if self.selected_fid_empty_files and self._checked("RecFID_CheckBox_SubtractEmpty", True) else None
+
+        for index, file_name in enumerate(self.selected_data_files):
+            data_empty = self.selected_data_empty_files[index] if self.selected_data_empty_files else None
             result = recfid.analyze_signal(file_name, fid, data_empty, fid_empty, self._analysis_options())
-            state.data_results[file_name] = {
+            self.data_results[file_name] = {
                 "Time_td": result.time_data,
                 "Re_td": result.signal_data,
                 "Freq": result.frequency_data,
@@ -164,67 +161,61 @@ class RecFIDController(BaseTabController):
             }
             se_max.append(float(np.max(result.signal_data)))
             se_t2.append(result.t2_data)
-        extrapolation, fitting_curve, fittingx = recfid.find_maximum_se(echo_time, se_max, start, finish)
-        state.se_max = np.asarray(se_max, dtype=float)
-        state.se_t2 = np.asarray(se_t2, dtype=float)
-        state.echo_time_array = np.asarray(echo_time, dtype=float)
-        return extrapolation, state.echo_time_array, state.se_max, fittingx, fitting_curve
+
+        extrapolation, fitting_curve, fittingx = recfid.find_maximum_se(
+            echo_time,
+            se_max,
+            self._value("RecFID_DoubleSpinBox_SEFitFrom", 0.0),
+            self._value("RecFID_DoubleSpinBox_SEFitTo", 0.0),
+        )
+        self.se_max_result = {
+            "echo_time": np.asarray(echo_time, dtype=float),
+            "maximum": np.asarray(se_max, dtype=float),
+            "t2": np.asarray(se_t2, dtype=float),
+            "fit_x": fittingx,
+            "fit_y": fitting_curve,
+        }
+        return extrapolation
 
     def extrapolate(self):
-        state = self.recfid_state
-        graph_se = getattr(self.ui, "widgetSEMax", None)
-        self._update_mode_from_data_files()
-        if state.mode == "se":
-            start = self._value("doubleSpinBox_7", 0.0)
-            end = self._value("doubleSpinBox_6", 0.0)
-            extrapolation, echo_time, maximum_se, fittingx, fittingy = self.se_analysis(start, end)
-            state.extrapolation = extrapolation
-            if graph_se is not None:
-                graph_se.clear()
-                graph_se.show()
-                graph_se.plot([0], [extrapolation], pen="r", symbolPen=None, symbol="o", symbolBrush="r")
-                graph_se.plot(fittingx, fittingy, pen=mkPen("k", width=3, style=Qt.DashLine), symbol=None)
-                graph_se.plot(echo_time, maximum_se, pen=None, symbolPen=None, symbol="o", symbolBrush="b")
-        else:
-            result = self.compare()
-            extrapolation = float(np.max(result.signal_data))
-            if state.mode == "mse":
-                extrapolation /= max(self._value("doubleSpinBox_8", 2.0), 1.0)
-            state.extrapolation = extrapolation
-            state.se_max = np.array([float(np.max(result.signal_data))])
-            state.se_t2 = np.array([result.t2_data])
-            state.echo_time_array = np.array([0.0])
-            state.data_results[state.mode.upper()] = {
-                "Time_td": result.time_data,
-                "Re_td": result.signal_data,
-                "Freq": result.frequency_data,
-                "Real_fft": result.spectrum_data,
-                "M2": result.m2_data,
-                "T2": result.t2_data,
+        if self.recfid_mode == "se":
+            extrapolation = self.run_se_analysis()
+            self.extrapolation = extrapolation
+            self._plot_se_maximum()
+        elif self.recfid_mode == "mse":
+            result = self.run_basic_data_analysis()
+            raw_maximum = float(np.max(result.signal_data))
+            divider = max(self._value("RecFID_DoubleSpinBox_MseDivider", 2.0), 1.0)
+            self.extrapolation = raw_maximum / divider
+            self.se_max_result = {
+                "echo_time": np.array([0.0]),
+                "maximum": np.array([raw_maximum]),
+                "t2": np.array([result.t2_data]),
             }
-            if graph_se is not None:
-                graph_se.clear()
-                graph_se.hide()
-        self._status(f"RecFID max = {round(state.extrapolation, 2)}")
-        return state.extrapolation
+            self._clear_or_hide("RecFID_PlotWidget_SEMax", hide=True)
+        else:
+            raise ValueError("Load one data file for MSE mode or multiple data files for SE mode before running.")
 
-    def build_up(self, begin, finish):
-        state = self.recfid_state
-        if state.extrapolation is None:
+        self._status(f"RecFID max = {round(self.extrapolation, 2)}")
+        return self.extrapolation
+
+    def build_up(self):
+        if self.extrapolation is None:
             raise ValueError("Run extrapolation before build-up.")
-        fid = state.fid_result
-        if not fid:
+        if not self.fid_result:
             raise ValueError("Run FID/data analysis before build-up.")
+        begin = self._value("RecFID_DoubleSpinBox_BuildFrom", 9.0)
+        finish = self._value("RecFID_DoubleSpinBox_BuildTo", 20.0)
         time_build, data_build, data_fit, freq_build, spectrum_build, m2_build, t2_build = recfid.analyze_build_up(
-            fid["Time_td_fid"],
-            fid["Re_td"],
-            state.extrapolation,
-            self._text("comboBox", "Gaussian"),
+            self.fid_result["Time_td_fid"],
+            self.fid_result["Re_td"],
+            self.extrapolation,
+            self._text("RecFID_ComboBox_BuildFunction", "Gaussian"),
             begin,
             finish,
-            self._value("doubleSpinBox_5", 100.0),
+            self._value("RecFID_DoubleSpinBox_ApodizationSigma", 100.0),
         )
-        state.build_result = {
+        self.build_result = {
             "Time": time_build,
             "Re": data_build,
             "Fit": data_fit,
@@ -233,41 +224,21 @@ class RecFIDController(BaseTabController):
             "M2": float(m2_build),
             "T2": float(t2_build),
         }
-        graph_build_fid = getattr(self.ui, "widgetBUNMRSignal", None)
-        if graph_build_fid is not None:
-            graph_build_fid.clear()
-            graph_build_fid.plot(time_build, data_build, pen=mkPen("b", width=3), symbol=None)
-            graph_build_fid.plot(fid["Time_td_fid"], fid["Re_td"], pen=mkPen("r", width=3), symbol=None)
-        graph_build_fft = getattr(self.ui, "widgetBUFFT", None)
-        if graph_build_fft is not None:
-            graph_build_fft.clear()
-            graph_build_fft.plot(freq_build, spectrum_build, pen=mkPen("b", width=3), symbol=None)
-            graph_build_fft.plot(fid["Freq"], fid["Real_fft"], pen=mkPen("r", width=3), symbol=None)
+        self._plot_build_up(freq_build, spectrum_build, time_build, data_build)
         self._status(
-            f"Build-up T₂*={round(t2_build, 5)}, M₂={round(m2_build, 5)}; FID T₂*={fid['T2']}, M₂={fid['M2']}"
+            f"Build-up T₂*={round(t2_build, 5)}, M₂={round(m2_build, 5)}; "
+            f"FID T₂*={self.fid_result['T2']}, M₂={self.fid_result['M2']}"
         )
         return m2_build, t2_build
 
-    def manual_assignment(self):
-        if not self.recfid_state.data_files:
-            self._warn("No SE files", "Load (M)SE files before assigning echo times manually.")
-            return
-        dialog = RecFIDManualEchoTimeDialog(
-            self.recfid_state.data_files, self.recfid_state.manual_echo_times, self.parent
-        )
-        if dialog.exec():
-            try:
-                self.recfid_state.manual_echo_times = dialog.echo_times()
-                self.recfid_state.manual_assignment = True
-            except ValueError as exc:
-                self._warn("Invalid echo time", str(exc))
-
-    def time_analysis(self):
-        if not self.recfid_state.fid_result:
+    def run_time_analysis(self):
+        if not self.fid_result or self.extrapolation is None:
             self._warn("No build-up data", "Run RecFID analysis before analysing time ranges.")
             return
         with busy_cursor():
-            start_range, finish_range, m2_values, t2_values = self._calculate_time_analysis(self._text("comboBox", "Gaussian"))
+            start_range, finish_range, m2_values, t2_values = self._calculate_time_analysis(
+                self._text("RecFID_ComboBox_BuildFunction", "Gaussian")
+            )
         dialog = RecFIDTimeAnalysisDialog(self.parent)
         dialog.plot_data(start_range, finish_range, t2_values, m2_values)
         dialog.setWindowTitle("RecFID T2 Map")
@@ -276,7 +247,7 @@ class RecFIDController(BaseTabController):
         self._plot_window = dialog
 
     def save_statistics(self):
-        if not self.recfid_state.fid_result:
+        if not self.fid_result or self.extrapolation is None:
             self._warn("No build-up data", "Run RecFID analysis before exporting a T2 map.")
             return
         file_path, _ = QFileDialog.getSaveFileName(
@@ -288,17 +259,17 @@ class RecFIDController(BaseTabController):
         )
         if not file_path:
             return
+        combo = getattr(self.ui, "RecFID_ComboBox_BuildFunction")
         with busy_cursor():
-            for index in range(getattr(self.ui, "comboBox").count()):
-                self.ui.comboBox.setCurrentIndex(index)
-                start_range, finish_range, _m2, t2 = self._calculate_time_analysis(self.ui.comboBox.currentText())
+            for index in range(combo.count()):
+                combo.setCurrentIndex(index)
+                start_range, finish_range, _m2, t2 = self._calculate_time_analysis(combo.currentText())
                 ranges = [(begin, finish) for begin in start_range for finish in finish_range]
-                self._write_frequencies_t2(ranges, t2.flatten(), file_path, self.ui.comboBox.currentText())
+                self._write_frequencies_t2(ranges, t2.flatten(), file_path, combo.currentText())
         self._status(f"Saved RecFID statistics to {file_path}")
 
-    def exportSEMaxT2(self):
-        state = self.recfid_state
-        if state.extrapolation is None or state.se_max.size == 0:
+    def export_se_max_t2(self):
+        if self.extrapolation is None or not self.se_max_result:
             self._warn("No SE maxima", "Run RecFID analysis before exporting SE maxima and T2 values.")
             return
         file_path, _ = QFileDialog.getSaveFileName(
@@ -311,35 +282,75 @@ class RecFIDController(BaseTabController):
         if not file_path:
             return
         with open(file_path, "a", encoding="utf-8") as handle:
-            handle.write(f"Max Extrapolation: {state.extrapolation}\n")
+            handle.write(f"Max Extrapolation: {self.extrapolation}\n")
             handle.write("Echo Time\tT2\tRatio\tEcho Amp\n")
-            for echo_time, maximum, t2 in zip(state.echo_time_array, state.se_max, state.se_t2):
-                ratio = state.extrapolation / maximum if maximum else 0
+            for echo_time, maximum, t2 in zip(
+                self.se_max_result.get("echo_time", []),
+                self.se_max_result.get("maximum", []),
+                self.se_max_result.get("t2", []),
+            ):
+                ratio = self.extrapolation / maximum if maximum else 0
                 handle.write(f"{echo_time}\t{t2}\t{ratio}\t{maximum}\t\n")
             handle.write("\n")
         self._status(f"Saved RecFID SE maxima and T2 values to {file_path}")
 
+    def open_manual_echo_time_dialog(self):
+        if not self.selected_data_files:
+            self._warn("No SE files", "Load (M)SE files before assigning echo times manually.")
+            return
+        dialog = RecFIDManualEchoTimeDialog(self.selected_data_files, self.echo_time_values, self.parent)
+        if dialog.exec():
+            try:
+                self.echo_time_values = dialog.echo_times()
+                self.manual_echo_time_enabled = True
+            except ValueError as exc:
+                self._warn("Invalid echo time", str(exc))
+
     def save_results(self):
-        if not self.recfid_state.build_result:
+        if not self.build_result:
             self._warn("No RecFID result", "Run RecFID analysis before saving reconstructed FID results.")
             return
         directory = QFileDialog.getExistingDirectory(self.parent, "Select RecFID export directory")
         if not directory:
             return
         base = Path(directory)
-        build = self.recfid_state.build_result
-        np.savetxt(base / "recfid_built_fid.csv", np.column_stack((build["Time"], build["Re"])), delimiter=",", header="Time,Re", comments="")
-        np.savetxt(base / "recfid_built_fft.csv", np.column_stack((build["Freq"], build["Real_fft"])), delimiter=",", header="Frequency,Amplitude", comments="")
-        for widget_name, file_name in (("widgetBUNMRSignal", "recfid_built_fid.png"), ("widgetBUFFT", "recfid_built_fft.png")):
+        np.savetxt(
+            base / "recfid_built_fid.csv",
+            np.column_stack((self.build_result["Time"], self.build_result["Re"])),
+            delimiter=",",
+            header="Time,Re",
+            comments="",
+        )
+        np.savetxt(
+            base / "recfid_built_fft.csv",
+            np.column_stack((self.build_result["Freq"], self.build_result["Real_fft"])),
+            delimiter=",",
+            header="Frequency,Amplitude",
+            comments="",
+        )
+        for widget_name, file_name in (
+            ("RecFID_PlotWidget_BuildUpNMRSignal", "recfid_built_fid.png"),
+            ("RecFID_PlotWidget_BuildUpSpectra", "recfid_built_fft.png"),
+        ):
             widget = getattr(self.ui, widget_name, None)
             if widget is not None:
                 exporter = pyqtgraph.exporters.ImageExporter(widget.plotItem)
                 exporter.export(str(base / file_name))
         self._status(f"Saved RecFID results to {directory}")
 
+    # Backward-compatible method aliases used by previous controller wiring/tests.
+    reset = reset_tab
+    run = run_full_pipeline
+    compare = run_basic_data_analysis
+    se_analysis = run_se_analysis
+    manual_assignment = open_manual_echo_time_dialog
+    time_analysis = run_time_analysis
+    exportSEMaxT2 = export_se_max_t2
+
     def _calculate_time_analysis(self, function_name):
-        fid = self.recfid_state.fid_result
-        start_range, finish_range = recfid.time_range_grid(fid["Time_td_fid"], self._value("spinBoxTimeRange", 24))
+        start_range, finish_range = recfid.time_range_grid(
+            self.fid_result["Time_td_fid"], self._value("RecFID_SpinBox_TimeAnalysisRange", 24)
+        )
         m2 = []
         t2 = []
         for begin in start_range:
@@ -349,8 +360,14 @@ class RecFIDController(BaseTabController):
                     t2_build = 0
                 else:
                     try:
-                        _tb, _db, _df, freq, spectrum, m2_build, t2_build = recfid.analyze_build_up(
-                            fid["Time_td_fid"], fid["Re_td"], self.recfid_state.extrapolation, function_name, begin, finish, self._value("doubleSpinBox_5", 100.0)
+                        _tb, _db, _df, _freq, _spectrum, m2_build, t2_build = recfid.analyze_build_up(
+                            self.fid_result["Time_td_fid"],
+                            self.fid_result["Re_td"],
+                            self.extrapolation,
+                            function_name,
+                            begin,
+                            finish,
+                            self._value("RecFID_DoubleSpinBox_ApodizationSigma", 100.0),
                         )
                     except Exception:
                         logger.exception("RecFID time-analysis point failed: begin=%s finish=%s", begin, finish)
@@ -367,8 +384,8 @@ class RecFIDController(BaseTabController):
 
     def _write_frequencies_t2(self, ranges, t2s, file_path, function_name):
         with open(file_path, "a", encoding="utf-8") as handle:
-            handle.write(f"Name: {self.recfid_state.fid_files}\n")
-            handle.write(f"Mode: {self.recfid_state.mode}\n")
+            handle.write(f"Name: {self.selected_fid_files}\n")
+            handle.write(f"Mode: {self.recfid_mode}\n")
             handle.write(f"Function: {function_name}\n\n")
             for range_bf, t2 in zip(ranges, t2s):
                 handle.write(f"{range_bf[0]}\t{range_bf[1]}\t{t2}\t\n")
@@ -376,67 +393,129 @@ class RecFIDController(BaseTabController):
 
     def _analysis_options(self):
         return recfid.AnalysisOptions(
-            subtract_empty=self._checked("checkBox_subempty", True),
-            cut_beginning=self._checked("checkBox_cutbegin", True),
-            normalize_to_fid=self._checked("checkBox_normtofid", True),
-            normalize_from=self._value("doubleSpinBox", 70.0),
-            normalize_to=self._value("doubleSpinBox_2", 90.0),
-            long_component=self._checked("checkBox_longcomp", False),
-            long_component_from=self._value("doubleSpinBox_4", 55.0),
-            apodize_time_domain=self._checked("checkBox_td_apodization", True),
-            apodization_time=self._value("doubleSpinBox_5", 100.0),
-            adjust_frequency_phase=True,
-            adjust_fid_zero=self._checked("checkBox_adjust_zero", False),
-            fid_zero_shift=self._value("doubleSpinBox_3", 0.0),
-            smooth=self._checked("checkBoxSmooth", False),
-            smooth_order=int(self._value("spinBoxOrder", 1)),
-            smooth_window=int(self._value("spinBoxWindow", 5)),
+            subtract_empty=self._checked("RecFID_CheckBox_SubtractEmpty", True),
+            cut_beginning=self._checked("RecFID_CheckBox_CutBeginning", True),
+            normalize_to_fid=self._checked("RecFID_CheckBox_NormalizeToFID", True),
+            normalize_from=self._value("RecFID_DoubleSpinBox_NormalizeFrom", 70.0),
+            normalize_to=self._value("RecFID_DoubleSpinBox_NormalizeTo", 90.0),
+            long_component=self._checked("RecFID_CheckBox_LongComponent", False),
+            long_component_from=self._value("RecFID_DoubleSpinBox_LongComponentEnd", 55.0),
+            apodize_time_domain=self._checked("RecFID_CheckBox_TimeDomainApodization", True),
+            apodization_time=self._value("RecFID_DoubleSpinBox_ApodizationSigma", 100.0),
+            adjust_frequency_phase=self._checked("RecFID_CheckBox_AdjustFrequencyPhase", True),
+            adjust_fid_zero=self._checked("RecFID_CheckBox_AdjustZero", False),
+            fid_zero_shift=self._value("RecFID_DoubleSpinBox_ZeroShift", 0.0),
+            smooth=self._checked("RecFID_CheckBox_Smooth", False),
+            smooth_order=int(self._value("RecFID_SpinBox_SmoothOrder", 1)),
+            smooth_window=int(self._value("RecFID_SpinBox_SmoothWindow", 5)),
         )
 
     def _choose_files_for_comparison(self, number):
-        state = self.recfid_state
-        if state.mode == "se":
-            data = state.data_files[number]
-            data_empty = state.data_empty_files[number] if state.data_empty_files else None
+        if self.recfid_mode == "se":
+            data = self.selected_data_files[number]
+            data_empty = self.selected_data_empty_files[number] if self.selected_data_empty_files else None
         else:
-            data = state.data_files[0]
-            data_empty = state.data_empty_files[0] if state.data_empty_files else None
-        return data, data_empty, state.fid_files[0], state.fid_empty_files[0] if state.fid_empty_files else None
+            data = self.selected_data_files[0]
+            data_empty = self.selected_data_empty_files[0] if self.selected_data_empty_files else None
+        fid_empty = self.selected_fid_empty_files[0] if self.selected_fid_empty_files else None
+        return data, data_empty, self.selected_fid_files[0], fid_empty
 
     def _echo_times_for_se_files(self):
-        state = self.recfid_state
-        if state.manual_assignment:
-            return state.manual_echo_times
-        echo_time = []
+        if self.manual_echo_time_enabled:
+            return self.echo_time_values
+        echo_times = []
         try:
-            for file_name in state.data_files:
-                echo_time.append(recfid.extract_echo_time(file_name))
+            for file_name in self.selected_data_files:
+                echo_times.append(recfid.extract_echo_time(file_name))
         except ValueError:
-            self.manual_assignment()
-            if not state.manual_assignment:
+            self.open_manual_echo_time_dialog()
+            if not self.manual_echo_time_enabled:
                 raise
-            echo_time = state.manual_echo_times
-        return echo_time
-
-    def _update_mode_from_data_files(self):
-        count = len(self.recfid_state.data_files)
-        if count > 4:
-            self.recfid_state.mode = "se"
-        elif count == 1:
-            self.recfid_state.mode = "mse"
-        elif count > 1:
-            self.recfid_state.mode = "single_se"
-        else:
-            self.recfid_state.mode = "none"
+            echo_times = self.echo_time_values
+        return echo_times
 
     def _validate_required_files(self):
-        if not self.recfid_state.fid_files:
+        if not self.selected_fid_files:
             self._warn("No FID file", "Load a FID file first.")
             return False
-        if not self.recfid_state.data_files:
+        if not self.selected_data_files:
             self._warn("No (M)SE file", "Load (M)SE data first.")
             return False
+        if self.recfid_mode not in {"mse", "se"}:
+            self.recfid_mode = "mse" if len(self.selected_data_files) == 1 else "se" if len(self.selected_data_files) > 1 else "none"
         return True
+
+    def _validate_empty_data_files(self):
+        if not self._checked("RecFID_CheckBox_SubtractEmpty", True) or not self.selected_data_empty_files:
+            return True
+        if self.recfid_mode == "mse" and len(self.selected_data_empty_files) == 1:
+            return True
+        if self.recfid_mode == "se" and len(self.selected_data_empty_files) == len(self.selected_data_files):
+            return True
+        self._warn(
+            "Different amount of files",
+            "The number of empty data files must match the number of data files when subtracting empty data. Empty data files were cleared.",
+        )
+        self.selected_data_empty_files = []
+        return True
+
+    def _plot_original_analysis(self, result):
+        graph_nmr = getattr(self.ui, "RecFID_PlotWidget_OriginalNMRSignal", None)
+        if graph_nmr is not None:
+            graph_nmr.clear()
+            graph_nmr.show()
+            graph_nmr.plot(result.time_data, result.signal_data, pen=mkPen("r", width=3), symbol=None)
+            graph_nmr.plot(result.time_fid, result.signal_fid, pen=mkPen("b", width=3), symbol=None)
+        graph_fft = getattr(self.ui, "RecFID_PlotWidget_OriginalSpectra", None)
+        if graph_fft is not None:
+            graph_fft.clear()
+            graph_fft.show()
+            graph_fft.plot(result.frequency_data, result.spectrum_data, pen=mkPen("r", width=3), symbol=None)
+            graph_fft.plot(result.frequency_fid, result.spectrum_fid, pen=mkPen("b", width=3), symbol=None)
+
+    def _plot_se_maximum(self):
+        graph = getattr(self.ui, "RecFID_PlotWidget_SEMax", None)
+        if graph is None:
+            return
+        graph.clear()
+        graph.show()
+        graph.plot([0], [self.extrapolation], pen="r", symbolPen=None, symbol="o", symbolBrush="r")
+        graph.plot(self.se_max_result["fit_x"], self.se_max_result["fit_y"], pen=mkPen("k", width=3, style=Qt.DashLine), symbol=None)
+        graph.plot(
+            self.se_max_result["echo_time"],
+            self.se_max_result["maximum"],
+            pen=None,
+            symbolPen=None,
+            symbol="o",
+            symbolBrush="b",
+        )
+
+    def _plot_build_up(self, freq_build, spectrum_build, time_build, data_build):
+        graph_build_fid = getattr(self.ui, "RecFID_PlotWidget_BuildUpNMRSignal", None)
+        if graph_build_fid is not None:
+            graph_build_fid.clear()
+            graph_build_fid.plot(time_build, data_build, pen=mkPen("b", width=3), symbol=None)
+            graph_build_fid.plot(self.fid_result["Time_td_fid"], self.fid_result["Re_td"], pen=mkPen("r", width=3), symbol=None)
+        graph_build_fft = getattr(self.ui, "RecFID_PlotWidget_BuildUpSpectra", None)
+        if graph_build_fft is not None:
+            graph_build_fft.clear()
+            graph_build_fft.plot(freq_build, spectrum_build, pen=mkPen("b", width=3), symbol=None)
+            graph_build_fft.plot(self.fid_result["Freq"], self.fid_result["Real_fft"], pen=mkPen("r", width=3), symbol=None)
+
+    def _clear_or_hide(self, widget_name, hide=False):
+        widget = getattr(self.ui, widget_name, None)
+        if widget is not None:
+            widget.clear()
+            if hide:
+                widget.hide()
+
+    def _select_files(self, multiple):
+        dialog = QFileDialog(self.parent)
+        dialog.setFileMode(QFileDialog.ExistingFiles if multiple else QFileDialog.ExistingFile)
+        dialog.setNameFilter("Data (*.dat *.txt *.csv)")
+        if dialog.exec():
+            return dialog.selectedFiles()
+        return None
 
     def _connect(self, widget_name, signal_name, slot):
         widget = getattr(self.ui, widget_name, None)
@@ -454,6 +533,7 @@ class RecFIDController(BaseTabController):
         if widget is None:
             return
         widget.clear()
+        widget.show()
         widget.getAxis("left").setLabel(ylabel)
         widget.getAxis("bottom").setLabel(xlabel)
         widget.setTitle(title)

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -14,6 +14,8 @@ from calculations import recfid_signal as recfid
 from controllers.base_tab_controller import BaseTabController
 from dialogs.recfid_dialogs import RecFIDTimeAnalysisDialog
 from dialogs.recfid_echo_time_dialog import RecFIDEchoTimeDialog
+from dialogs.open_files_dialog import OpenFilesDialog
+import dialogs.open_files_dialog as open_files_dialog_module
 from utils.ui_busy import busy_cursor
 
 logger = logging.getLogger(__name__)
@@ -39,8 +41,11 @@ class RecFIDController(BaseTabController):
         self.se_max_result = {}
         self.extrapolation = None
         self.build_result = {}
+        self.time_analysis_result = {}
+        self._close_time_analysis_dialog()
         if clear_plots:
             self.initialize_plots()
+            self._clear_result_text_widgets()
 
     def connect_signals(self):
         self._connect("RecFID_Button_LoadFID", "clicked", self.load_fid_files)
@@ -65,7 +70,6 @@ class RecFIDController(BaseTabController):
 
     def initialize_plots(self):
         self._setup_graph("RecFID_PlotWidget_OriginalNMRSignal", "Time, μs", "Amplitude", "FID / data")
-        self._setup_graph("RecFID_PlotWidget_OriginalSpectra", "Frequency, MHz", "Amplitude, a.u", "FFT")
         self._setup_graph("RecFID_PlotWidget_SEMax", "Echo Time, μs", "Amplitude", "SE Max")
         self._setup_graph("RecFID_PlotWidget_BuildUpNMRSignal", "Time, μs", "Amplitude", "FID Build")
         self._setup_graph("RecFID_PlotWidget_BuildUpSpectra", "Frequency, MHz", "Amplitude, a.u", "FFT Build")
@@ -106,7 +110,8 @@ class RecFIDController(BaseTabController):
             if not self._validate_required_files() or not self._validate_empty_data_files():
                 return
             try:
-                self.run_basic_data_analysis()
+                if self.run_basic_data_analysis() is None:
+                    return
                 if self.extrapolate() is None:
                     return
                 self.build_up()
@@ -130,6 +135,9 @@ class RecFIDController(BaseTabController):
     def run_basic_data_analysis(self):
         data, data_empty, fid, fid_empty = self._choose_files_for_comparison(0)
         result = recfid.analyze_signal(data, fid, data_empty, fid_empty, self._analysis_options())
+        result = self._apply_mse_divider_to_analysis_result(result)
+        if result is None:
+            return None
         self.fid_result = {
             "Time_td_fid": result.time_fid,
             "Re_td": result.signal_fid,
@@ -185,14 +193,13 @@ class RecFIDController(BaseTabController):
             self._plot_se_maximum()
         elif self.recfid_mode == "mse":
             result = self.run_basic_data_analysis()
-            raw_maximum = float(np.max(result.signal_data))
-            divider = self._validated_mse_divider()
-            if divider is None:
+            if result is None:
                 self.extrapolation = None
                 self.se_max_result = {}
                 self.build_result = {}
                 return None
-            self.extrapolation = raw_maximum / divider
+            raw_maximum = float(np.max(result.signal_data))
+            self.extrapolation = raw_maximum
             self.se_max_result = {
                 "echo_time": np.array([0.0]),
                 "maximum": np.array([raw_maximum]),
@@ -251,6 +258,12 @@ class RecFIDController(BaseTabController):
         dialog.resize(800, 600)
         dialog.show()
         self._plot_window = dialog
+        self.time_analysis_result = {
+            "start_range": start_range,
+            "finish_range": finish_range,
+            "m2": m2_values,
+            "t2": t2_values,
+        }
 
     def save_statistics(self):
         if not self.fid_result or self.extrapolation is None:
@@ -469,6 +482,31 @@ class RecFIDController(BaseTabController):
         self.selected_data_empty_files = []
         return True
 
+
+    def _apply_mse_divider_to_analysis_result(self, result):
+        if self.recfid_mode != "mse":
+            return result
+        divider = self._validated_mse_divider()
+        if divider is None:
+            return None
+        # In MSE mode the divider represents phase averaging; apply it before
+        # plotting, extrapolation, and build-up so FID and MSE amplitudes share
+        # the same scaled reference frame.
+        return recfid.SignalAnalysisResult(
+            time_data=result.time_data,
+            signal_data=result.signal_data / divider,
+            time_fid=result.time_fid,
+            signal_fid=result.signal_fid / divider,
+            frequency_data=result.frequency_data,
+            spectrum_data=result.spectrum_data / divider,
+            frequency_fid=result.frequency_fid,
+            spectrum_fid=result.spectrum_fid / divider,
+            m2_data=result.m2_data,
+            t2_data=result.t2_data,
+            m2_fid=result.m2_fid,
+            t2_fid=result.t2_fid,
+        )
+
     def _data_result_from_analysis(self, result):
         return {
             "Time_td": result.time_data,
@@ -490,54 +528,29 @@ class RecFIDController(BaseTabController):
         if not self.fid_result:
             return
         graph_nmr = getattr(self.ui, "RecFID_PlotWidget_OriginalNMRSignal", None)
-        if graph_nmr is not None:
-            self._prepare_plot_with_legend(graph_nmr)
-            fid_label = f"FID: {Path(self.selected_fid_files[0]).name}" if self.selected_fid_files else "FID"
+        if graph_nmr is None:
+            return
+        self._prepare_plot(graph_nmr)
+        graph_nmr.plot(
+            self.fid_result["Time_td_fid"],
+            self.fid_result["Re_td"],
+            pen=mkPen(QColor(220, 20, 60), width=3),
+            symbol=None,
+        )
+        for index, result in enumerate(self.data_results.values()):
             graph_nmr.plot(
-                self.fid_result["Time_td_fid"],
-                self.fid_result["Re_td"],
-                pen=mkPen(QColor(220, 20, 60), width=3),
+                result["Time_td"],
+                result["Re_td"],
+                pen=mkPen(self._winter_color(index, max(len(self.data_results), 1)), width=2),
                 symbol=None,
-                name=fid_label,
             )
-            for index, (file_path, result) in enumerate(self.data_results.items()):
-                color = self._winter_color(index, max(len(self.data_results), 1))
-                graph_nmr.plot(
-                    result["Time_td"],
-                    result["Re_td"],
-                    pen=mkPen(color, width=2),
-                    symbol=None,
-                    name=f"Data {index + 1}: {Path(file_path).name}",
-                )
+        self._status("Original NMR plot: red = FID; data curves use a winter color scale by echo time/file order.")
 
-        graph_fft = getattr(self.ui, "RecFID_PlotWidget_OriginalSpectra", None)
-        if graph_fft is not None:
-            self._prepare_plot_with_legend(graph_fft)
-            fid_label = f"FID: {Path(self.selected_fid_files[0]).name}" if self.selected_fid_files else "FID"
-            graph_fft.plot(
-                self.fid_result["Freq"],
-                self.fid_result["Real_fft"],
-                pen=mkPen(QColor(220, 20, 60), width=3),
-                symbol=None,
-                name=fid_label,
-            )
-            for index, (file_path, result) in enumerate(self.data_results.items()):
-                color = self._winter_color(index, max(len(self.data_results), 1))
-                graph_fft.plot(
-                    result["Freq"],
-                    result["Real_fft"],
-                    pen=mkPen(color, width=2),
-                    symbol=None,
-                    name=f"Data {index + 1}: {Path(file_path).name}",
-                )
-
-    def _prepare_plot_with_legend(self, graph):
+    def _prepare_plot(self, graph):
         graph.clear()
         graph.show()
         legend = getattr(graph.plotItem, "legend", None)
-        if legend is None:
-            graph.addLegend()
-        else:
+        if legend is not None:
             legend.clear()
 
     def _winter_color(self, index, total):
@@ -583,9 +596,8 @@ class RecFIDController(BaseTabController):
                 widget.hide()
 
     def _select_files(self, multiple):
-        dialog = QFileDialog(self.parent)
-        dialog.setFileMode(QFileDialog.ExistingFiles if multiple else QFileDialog.ExistingFile)
-        dialog.setNameFilter("Data (*.dat *.txt *.csv)")
+        open_files_dialog_module.State_multiple_files = multiple
+        dialog = OpenFilesDialog(self.parent)
         if dialog.exec():
             return dialog.selectedFiles()
         return None
@@ -606,10 +618,29 @@ class RecFIDController(BaseTabController):
         if widget is None:
             return
         widget.clear()
+        legend = getattr(widget.plotItem, "legend", None)
+        if legend is not None:
+            legend.clear()
         widget.show()
         widget.getAxis("left").setLabel(ylabel)
         widget.getAxis("bottom").setLabel(xlabel)
         widget.setTitle(title)
+
+    def _clear_result_text_widgets(self):
+        for widget_name in (
+            "RecFID_TextEdit_OriginalResults",
+            "RecFID_TextEdit_SEMaxResult",
+            "RecFID_TextEdit_BuildUpResults",
+        ):
+            widget = getattr(self.ui, widget_name, None)
+            if widget is not None:
+                widget.clear()
+
+    def _close_time_analysis_dialog(self):
+        dialog = getattr(self, "_plot_window", None)
+        if dialog is not None:
+            dialog.close()
+            self._plot_window = None
 
     def _checked(self, widget_name, default=False):
         widget = getattr(self.ui, widget_name, None)

--- a/dialogs/phasing_manual.py
+++ b/dialogs/phasing_manual.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.integrate import trapezoid
 from scipy.signal import savgol_filter
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QDialog, QMessageBox
@@ -85,7 +86,7 @@ class PhasingManual(QDialog):
 
     def update_text(self):
 
-        Integral=np.trapz(self.Real_freq_phased)
+        Integral=trapezoid(self.Real_freq_phased)
         delta=np.mean(self.Real_freq_phased[:100])-np.mean(self.Real_freq_phased[-100:])
         M2,T2=Cal._calculate_M2(Cal._calculate_apodization(self.Real_freq_phased, Frequency), Frequency)
 

--- a/dialogs/recfid_dialogs.py
+++ b/dialogs/recfid_dialogs.py
@@ -3,64 +3,10 @@
 from __future__ import annotations
 
 import numpy as np
+import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import (
-    QCheckBox,
-    QDialog,
-    QFileDialog,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QSlider,
-    QTableWidget,
-    QTableWidgetItem,
-    QVBoxLayout,
-)
-import matplotlib.pyplot as plt
-
-
-class RecFIDManualEchoTimeDialog(QDialog):
-    """Manual echo-time assignment for SE file lists."""
-
-    def __init__(self, files, echo_times=None, parent=None):
-        super().__init__(parent)
-        self.setWindowTitle("Manual Echo Time")
-        self.resize(700, 400)
-        echo_times = echo_times or []
-
-        self.table = QTableWidget(len(files), 2, self)
-        self.table.setHorizontalHeaderLabels(["File", "Echo Time, μs"])
-        for row, file_path in enumerate(files):
-            file_item = QTableWidgetItem(str(file_path))
-            file_item.setFlags(file_item.flags() & ~Qt.ItemIsEditable)
-            self.table.setItem(row, 0, file_item)
-            value = echo_times[row] if row < len(echo_times) else ""
-            self.table.setItem(row, 1, QTableWidgetItem(str(value)))
-        self.table.resizeColumnsToContents()
-
-        ok_button = QPushButton("OK")
-        ok_button.clicked.connect(self.accept)
-        cancel_button = QPushButton("Cancel")
-        cancel_button.clicked.connect(self.reject)
-        button_layout = QHBoxLayout()
-        button_layout.addStretch(1)
-        button_layout.addWidget(ok_button)
-        button_layout.addWidget(cancel_button)
-
-        layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Enter echo times for each loaded SE file."))
-        layout.addWidget(self.table)
-        layout.addLayout(button_layout)
-
-    def echo_times(self):
-        values = []
-        for row in range(self.table.rowCount()):
-            item = self.table.item(row, 1)
-            if item is None or item.text().strip() == "":
-                raise ValueError("Every SE file needs an echo time.")
-            values.append(float(item.text()))
-        return values
+from PySide6.QtWidgets import QCheckBox, QDialog, QFileDialog, QHBoxLayout, QLabel, QPushButton, QSlider, QVBoxLayout
 
 
 class RecFIDTimeAnalysisDialog(QDialog):
@@ -96,6 +42,7 @@ class RecFIDTimeAnalysisDialog(QDialog):
         self.m2 = None
 
     def plot_data(self, start_range, finish_range, t2, m2):
+        """Render the supplied M2/T2 grids into the dialog canvas."""
         self.start_range = np.asarray(start_range)
         self.finish_range = np.asarray(finish_range)
         self.t2 = np.asarray(t2)
@@ -103,6 +50,7 @@ class RecFIDTimeAnalysisDialog(QDialog):
         self.update_plot()
 
     def update_plot(self):
+        """Refresh the heatmap using the current threshold and color-map settings."""
         if self.t2 is None or self.m2 is None:
             return
         max_t2 = np.nanmax(self.t2)
@@ -113,11 +61,11 @@ class RecFIDTimeAnalysisDialog(QDialog):
         t2_masked = np.ma.masked_where((self.t2 < 5) | (self.t2 > threshold), self.t2)
         cmap = "rainbow" if self.rainbow_checkbox.isChecked() else "RdYlGn"
         self.canvas.figure.clf()
-        gs = self.canvas.figure.add_gridspec(1, 2, width_ratios=[1, 1], wspace=0.1)
-        ax_main = self.canvas.figure.add_subplot(gs[0])
-        ax_hist = self.canvas.figure.add_subplot(gs[1])
-        c = ax_main.pcolormesh(self.finish_range, self.start_range, t2_masked, shading="auto", cmap=cmap)
-        self.canvas.figure.colorbar(c, ax=ax_main, label="T₂ Value")
+        grid = self.canvas.figure.add_gridspec(1, 2, width_ratios=[1, 1], wspace=0.1)
+        ax_main = self.canvas.figure.add_subplot(grid[0])
+        ax_hist = self.canvas.figure.add_subplot(grid[1])
+        heatmap = ax_main.pcolormesh(self.finish_range, self.start_range, t2_masked, shading="auto", cmap=cmap)
+        self.canvas.figure.colorbar(heatmap, ax=ax_main, label="T₂ Value")
         ax_main.set_xlabel("Finish Range")
         ax_main.set_ylabel("Start Range")
         ax_main.set_xlim(self.finish_range[0], self.finish_range[-1])
@@ -134,6 +82,7 @@ class RecFIDTimeAnalysisDialog(QDialog):
         self.canvas.draw()
 
     def save_data(self):
+        """Export the currently displayed time-analysis grid."""
         if self.start_range is None or self.finish_range is None or self.t2 is None or self.m2 is None:
             return
         file_path, _ = QFileDialog.getSaveFileName(
@@ -150,3 +99,8 @@ class RecFIDTimeAnalysisDialog(QDialog):
             )
         )
         np.savetxt(file_path, data, delimiter=",", header="Start Range,Finish Range,M2Value,T2 Value", comments="")
+
+    def closeEvent(self, event):
+        plt.close(self.canvas.figure)
+        self.deleteLater()
+        event.accept()

--- a/dialogs/recfid_dialogs.py
+++ b/dialogs/recfid_dialogs.py
@@ -1,0 +1,152 @@
+"""Dialogs used by the Reconstruct FID tab."""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSlider,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+import matplotlib.pyplot as plt
+
+
+class RecFIDManualEchoTimeDialog(QDialog):
+    """Manual echo-time assignment for SE file lists."""
+
+    def __init__(self, files, echo_times=None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Manual Echo Time")
+        self.resize(700, 400)
+        echo_times = echo_times or []
+
+        self.table = QTableWidget(len(files), 2, self)
+        self.table.setHorizontalHeaderLabels(["File", "Echo Time, μs"])
+        for row, file_path in enumerate(files):
+            file_item = QTableWidgetItem(str(file_path))
+            file_item.setFlags(file_item.flags() & ~Qt.ItemIsEditable)
+            self.table.setItem(row, 0, file_item)
+            value = echo_times[row] if row < len(echo_times) else ""
+            self.table.setItem(row, 1, QTableWidgetItem(str(value)))
+        self.table.resizeColumnsToContents()
+
+        ok_button = QPushButton("OK")
+        ok_button.clicked.connect(self.accept)
+        cancel_button = QPushButton("Cancel")
+        cancel_button.clicked.connect(self.reject)
+        button_layout = QHBoxLayout()
+        button_layout.addStretch(1)
+        button_layout.addWidget(ok_button)
+        button_layout.addWidget(cancel_button)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Enter echo times for each loaded SE file."))
+        layout.addWidget(self.table)
+        layout.addLayout(button_layout)
+
+    def echo_times(self):
+        values = []
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, 1)
+            if item is None or item.text().strip() == "":
+                raise ValueError("Every SE file needs an echo time.")
+            values.append(float(item.text()))
+        return values
+
+
+class RecFIDTimeAnalysisDialog(QDialog):
+    """Optional T2 map visualization for RecFID time-range analysis."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.canvas = FigureCanvas(plt.figure())
+        self.slider = QSlider(Qt.Horizontal)
+        self.slider.setMinimum(0)
+        self.slider.setMaximum(100)
+        self.slider.setValue(100)
+        self.slider.valueChanged.connect(self.update_plot)
+        self.slider_label = QLabel("T₂ Threshold: 100%")
+        self.rainbow_checkbox = QCheckBox("Rainbow")
+        self.rainbow_checkbox.stateChanged.connect(self.update_plot)
+        self.save_button = QPushButton("Save Data")
+        self.save_button.clicked.connect(self.save_data)
+
+        controls = QHBoxLayout()
+        controls.addWidget(self.slider_label)
+        controls.addWidget(self.slider)
+        controls.addWidget(self.rainbow_checkbox)
+        controls.addWidget(self.save_button)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.canvas)
+        layout.addLayout(controls)
+
+        self.start_range = None
+        self.finish_range = None
+        self.t2 = None
+        self.m2 = None
+
+    def plot_data(self, start_range, finish_range, t2, m2):
+        self.start_range = np.asarray(start_range)
+        self.finish_range = np.asarray(finish_range)
+        self.t2 = np.asarray(t2)
+        self.m2 = np.asarray(m2)
+        self.update_plot()
+
+    def update_plot(self):
+        if self.t2 is None or self.m2 is None:
+            return
+        max_t2 = np.nanmax(self.t2)
+        if not np.isfinite(max_t2) or max_t2 == 0:
+            max_t2 = 1
+        threshold = self.slider.value() / 100.0 * max_t2
+        self.slider_label.setText(f"T₂ Threshold: {threshold:.2f}")
+        t2_masked = np.ma.masked_where((self.t2 < 5) | (self.t2 > threshold), self.t2)
+        cmap = "rainbow" if self.rainbow_checkbox.isChecked() else "RdYlGn"
+        self.canvas.figure.clf()
+        gs = self.canvas.figure.add_gridspec(1, 2, width_ratios=[1, 1], wspace=0.1)
+        ax_main = self.canvas.figure.add_subplot(gs[0])
+        ax_hist = self.canvas.figure.add_subplot(gs[1])
+        c = ax_main.pcolormesh(self.finish_range, self.start_range, t2_masked, shading="auto", cmap=cmap)
+        self.canvas.figure.colorbar(c, ax=ax_main, label="T₂ Value")
+        ax_main.set_xlabel("Finish Range")
+        ax_main.set_ylabel("Start Range")
+        ax_main.set_xlim(self.finish_range[0], self.finish_range[-1])
+        ax_main.set_ylim(self.start_range[0], self.start_range[-1])
+        compressed = t2_masked.compressed()
+        if compressed.size:
+            ax_hist.hist(compressed, bins=20, color="blue")
+            ax_hist.set_xlim(float(np.min(compressed)), float(np.max(compressed)))
+        ax_hist.set_ylabel("Count")
+        ax_hist.yaxis.set_label_position("right")
+        ax_hist.yaxis.tick_right()
+        ax_hist.set_xlabel("T₂ value")
+        ax_main.set_title("T₂ Distribution")
+        self.canvas.draw()
+
+    def save_data(self):
+        if self.start_range is None or self.finish_range is None or self.t2 is None or self.m2 is None:
+            return
+        file_path, _ = QFileDialog.getSaveFileName(
+            self, "Save Data", "", "CSV Files (*.csv);;Text Files (*.txt)"
+        )
+        if not file_path:
+            return
+        data = np.column_stack(
+            (
+                self.start_range.repeat(len(self.finish_range)),
+                np.tile(self.finish_range, len(self.start_range)),
+                self.m2.flatten(),
+                self.t2.flatten(),
+            )
+        )
+        np.savetxt(file_path, data, delimiter=",", header="Start Range,Finish Range,M2Value,T2 Value", comments="")

--- a/dialogs/recfid_echo_time_dialog.py
+++ b/dialogs/recfid_echo_time_dialog.py
@@ -1,0 +1,58 @@
+"""Manual echo-time assignment dialog for RecFID SE files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QHBoxLayout, QLabel, QPushButton, QTableWidget, QTableWidgetItem, QVBoxLayout
+
+
+class RecFIDEchoTimeDialog(QDialog):
+    """Two-column filename/echo-time editor used when SE echo times cannot be parsed."""
+
+    def __init__(self, files, echo_times=None, parent=None):
+        super().__init__(parent)
+        self.setObjectName("RecFIDManual_Dialog_EchoTimes")
+        self.setWindowTitle("Manual Echo Time")
+        self.resize(700, 400)
+
+        echo_times = echo_times or []
+        self.RecFIDManual_Table_EchoTimes = QTableWidget(len(files), 2, self)
+        self.RecFIDManual_Table_EchoTimes.setObjectName("RecFIDManual_Table_EchoTimes")
+        self.RecFIDManual_Table_EchoTimes.setHorizontalHeaderLabels(["Filename", "Echo Time"])
+
+        for row, file_path in enumerate(files):
+            file_item = QTableWidgetItem(Path(file_path).name)
+            file_item.setData(Qt.UserRole, str(file_path))
+            file_item.setFlags(file_item.flags() & ~Qt.ItemIsEditable)
+            self.RecFIDManual_Table_EchoTimes.setItem(row, 0, file_item)
+            value = echo_times[row] if row < len(echo_times) else ""
+            self.RecFIDManual_Table_EchoTimes.setItem(row, 1, QTableWidgetItem(str(value)))
+        self.RecFIDManual_Table_EchoTimes.resizeColumnsToContents()
+
+        self.RecFIDManual_Button_Accept = QPushButton("Accept")
+        self.RecFIDManual_Button_Accept.setObjectName("RecFIDManual_Button_Accept")
+        self.RecFIDManual_Button_Accept.clicked.connect(self.accept)
+        cancel_button = QPushButton("Cancel")
+        cancel_button.clicked.connect(self.reject)
+
+        button_layout = QHBoxLayout()
+        button_layout.addStretch(1)
+        button_layout.addWidget(self.RecFIDManual_Button_Accept)
+        button_layout.addWidget(cancel_button)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Enter echo times for each loaded SE file."))
+        layout.addWidget(self.RecFIDManual_Table_EchoTimes)
+        layout.addLayout(button_layout)
+
+    def echo_times(self):
+        """Return manually entered echo times as floats."""
+        values = []
+        for row in range(self.RecFIDManual_Table_EchoTimes.rowCount()):
+            item = self.RecFIDManual_Table_EchoTimes.item(row, 1)
+            if item is None or item.text().strip() == "":
+                raise ValueError("Every SE file needs an echo time.")
+            values.append(float(item.text()))
+        return values

--- a/form.ui
+++ b/form.ui
@@ -5733,22 +5733,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   </widget>
                  </item>
                  <item>
-                  <widget class="PlotWidget" name="RecFID_PlotWidget_OriginalSpectra" native="true">
-                   <property name="minimumSize">
-                    <size>
-                     <width>300</width>
-                     <height>300</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
                   <widget class="PlotWidget" name="RecFID_PlotWidget_SEMax" native="true">
                    <property name="minimumSize">
                     <size>

--- a/form.ui
+++ b/form.ui
@@ -5377,7 +5377,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="QGroupBox" name="groupBox">
+                  <widget class="QGroupBox" name="RecFID_GroupBox_LoadExport">
                    <property name="minimumSize">
                     <size>
                      <width>150</width>
@@ -5407,56 +5407,63 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <number>5</number>
                     </property>
                     <item>
-                     <widget class="QPushButton" name="pushButton">
+                     <widget class="QPushButton" name="RecFID_Button_LoadFID">
                       <property name="text">
                        <string>Load FID</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pushButton_2">
+                     <widget class="QPushButton" name="RecFID_Button_LoadData">
                       <property name="text">
                        <string>Load (M)SE</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pushButton_3">
+                     <widget class="QPushButton" name="RecFID_Button_LoadFIDEmpty">
                       <property name="text">
                        <string>Load FID Empty</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pushButton_4">
+                     <widget class="QPushButton" name="RecFID_Button_LoadDataEmpty">
                       <property name="text">
                        <string>Load (M)SE Empty</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pushButton_5">
+                     <widget class="QPushButton" name="RecFID_Button_ManualEchoTimes">
                       <property name="text">
                        <string>Manual Echo Time</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="Btn_SaveStatistics">
+                     <widget class="QPushButton" name="RecFID_Button_Clear">
+                      <property name="text">
+                       <string>Clear</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="RecFID_Button_SaveStatistics">
                       <property name="text">
                        <string>Export T2 Map</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pushButtonExportMaxT2">
+                     <widget class="QPushButton" name="RecFID_Button_ExportSEMaxT2">
                       <property name="text">
                        <string>Export SE max and T2</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pushButtonGO">
+                     <widget class="QPushButton" name="RecFID_Button_Run">
                       <property name="enabled">
                        <bool>true</bool>
                       </property>
@@ -5469,7 +5476,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   </widget>
                  </item>
                  <item>
-                  <widget class="QGroupBox" name="groupBox_4">
+                  <widget class="QGroupBox" name="RecFID_GroupBox_DataAdjustment">
                    <property name="minimumSize">
                     <size>
                      <width>100</width>
@@ -5499,7 +5506,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <number>5</number>
                     </property>
                     <item>
-                     <widget class="QCheckBox" name="checkBox_subempty">
+                     <widget class="QCheckBox" name="RecFID_CheckBox_SubtractEmpty">
                       <property name="text">
                        <string>Subtract Empty</string>
                       </property>
@@ -5509,7 +5516,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="checkBox_cutbegin">
+                     <widget class="QCheckBox" name="RecFID_CheckBox_CutBeginning">
                       <property name="text">
                        <string>Cut the beginning</string>
                       </property>
@@ -5519,7 +5526,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="checkBox_normtofid">
+                     <widget class="QCheckBox" name="RecFID_CheckBox_NormalizeToFID">
                       <property name="text">
                        <string>Normalize to FID</string>
                       </property>
@@ -5529,7 +5536,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBox">
+                     <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_NormalizeFrom">
                       <property name="prefix">
                        <string>from </string>
                       </property>
@@ -5548,7 +5555,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBox_2">
+                     <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_NormalizeTo">
                       <property name="prefix">
                        <string>to </string>
                       </property>
@@ -5567,7 +5574,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="checkBox_longcomp">
+                     <widget class="QCheckBox" name="RecFID_CheckBox_LongComponent">
                       <property name="text">
                        <string>Long Component</string>
                       </property>
@@ -5577,7 +5584,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBox_4">
+                     <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_LongComponentEnd">
                       <property name="prefix">
                        <string>from </string>
                       </property>
@@ -5596,14 +5603,14 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="checkBoxSmooth">
+                     <widget class="QCheckBox" name="RecFID_CheckBox_Smooth">
                       <property name="text">
                        <string>Smooth</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="spinBoxOrder">
+                     <widget class="QSpinBox" name="RecFID_SpinBox_SmoothOrder">
                       <property name="suffix">
                        <string/>
                       </property>
@@ -5619,7 +5626,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="spinBoxWindow">
+                     <widget class="QSpinBox" name="RecFID_SpinBox_SmoothWindow">
                       <property name="prefix">
                        <string>window </string>
                       </property>
@@ -5632,7 +5639,17 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="checkBox_td_apodization">
+                     <widget class="QCheckBox" name="RecFID_CheckBox_AdjustFrequencyPhase">
+                      <property name="text">
+                       <string>Adjust Frequency/Phase</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="RecFID_CheckBox_TimeDomainApodization">
                       <property name="text">
                        <string>TD Apodization</string>
                       </property>
@@ -5642,7 +5659,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBox_5">
+                     <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_ApodizationSigma">
                       <property name="prefix">
                        <string>at </string>
                       </property>
@@ -5658,7 +5675,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="checkBox_adjust_zero">
+                     <widget class="QCheckBox" name="RecFID_CheckBox_AdjustZero">
                       <property name="text">
                        <string>Shift NMR Signal</string>
                       </property>
@@ -5668,7 +5685,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBox_3">
+                     <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_ZeroShift">
                       <property name="minimum">
                        <double>-10.000000000000000</double>
                       </property>
@@ -5700,7 +5717,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="PlotWidget" name="widgetOriginalNMRSignal" native="true">
+                  <widget class="PlotWidget" name="RecFID_PlotWidget_OriginalNMRSignal" native="true">
                    <property name="minimumSize">
                     <size>
                      <width>300</width>
@@ -5716,7 +5733,23 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   </widget>
                  </item>
                  <item>
-                  <widget class="PlotWidget" name="widgetSEMax" native="true">
+                  <widget class="PlotWidget" name="RecFID_PlotWidget_OriginalSpectra" native="true">
+                   <property name="minimumSize">
+                    <size>
+                     <width>300</width>
+                     <height>300</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="PlotWidget" name="RecFID_PlotWidget_SEMax" native="true">
                    <property name="minimumSize">
                     <size>
                      <width>300</width>
@@ -5761,7 +5794,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   </spacer>
                  </item>
                  <item>
-                  <widget class="QGroupBox" name="groupBox_7">
+                  <widget class="QGroupBox" name="RecFID_GroupBox_Reconstruction">
                    <property name="minimumSize">
                     <size>
                      <width>150</width>
@@ -5794,7 +5827,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <number>5</number>
                     </property>
                     <item>
-                     <widget class="QComboBox" name="comboBox">
+                     <widget class="QComboBox" name="RecFID_ComboBox_BuildFunction">
                       <property name="styleSheet">
                        <string notr="true">background: white</string>
                       </property>
@@ -5824,7 +5857,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBox_begin">
+                     <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_BuildFrom">
                       <property name="suffix">
                        <string>μs</string>
                       </property>
@@ -5843,7 +5876,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QDoubleSpinBox" name="doubleSpinBox_finish">
+                     <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_BuildTo">
                       <property name="suffix">
                        <string>μs</string>
                       </property>
@@ -5859,14 +5892,14 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="pushButton_analyse">
+                     <widget class="QPushButton" name="RecFID_Button_TimeAnalysis">
                       <property name="text">
                        <string>Analyse Times</string>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSpinBox" name="spinBoxTimeRange">
+                     <widget class="QSpinBox" name="RecFID_SpinBox_TimeAnalysisRange">
                       <property name="singleStep">
                        <number>1</number>
                       </property>
@@ -5892,7 +5925,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   </spacer>
                  </item>
                  <item>
-                  <widget class="QGroupBox" name="groupBox_5">
+                  <widget class="QGroupBox" name="RecFID_GroupBox_Maximum">
                    <property name="minimumSize">
                     <size>
                      <width>150</width>
@@ -5922,7 +5955,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <number>5</number>
                     </property>
                     <item>
-                     <widget class="QGroupBox" name="groupBox_9">
+                     <widget class="QGroupBox" name="RecFID_GroupBox_SE">
                       <property name="title">
                        <string>SE</string>
                       </property>
@@ -5940,7 +5973,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                         <number>5</number>
                        </property>
                        <item>
-                        <widget class="QDoubleSpinBox" name="doubleSpinBox_7">
+                        <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_SEFitFrom">
                          <property name="prefix">
                           <string>cut from </string>
                          </property>
@@ -5953,7 +5986,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                         </widget>
                        </item>
                        <item>
-                        <widget class="QDoubleSpinBox" name="doubleSpinBox_6">
+                        <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_SEFitTo">
                          <property name="prefix">
                           <string>cut to </string>
                          </property>
@@ -5969,7 +6002,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QGroupBox" name="groupBox_10">
+                     <widget class="QGroupBox" name="RecFID_GroupBox_MSE">
                       <property name="title">
                        <string>MSE</string>
                       </property>
@@ -5987,7 +6020,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                         <number>5</number>
                        </property>
                        <item>
-                        <widget class="QDoubleSpinBox" name="doubleSpinBox_8">
+                        <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_MseDivider">
                          <property name="prefix">
                           <string>derive by </string>
                          </property>
@@ -6038,7 +6071,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="PlotWidget" name="widgetBUNMRSignal" native="true">
+                  <widget class="PlotWidget" name="RecFID_PlotWidget_BuildUpNMRSignal" native="true">
                    <property name="minimumSize">
                     <size>
                      <width>300</width>
@@ -6054,7 +6087,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   </widget>
                  </item>
                  <item>
-                  <widget class="PlotWidget" name="widgetBUFFT" native="true">
+                  <widget class="PlotWidget" name="RecFID_PlotWidget_BuildUpSpectra" native="true">
                    <property name="minimumSize">
                     <size>
                      <width>300</width>

--- a/form.ui
+++ b/form.ui
@@ -567,7 +567,7 @@
               <enum>QTabWidget::Rounded</enum>
              </property>
              <property name="currentIndex">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="elideMode">
               <enum>Qt::ElideLeft</enum>
@@ -5667,7 +5667,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                     <item>
                      <widget class="QCheckBox" name="RecFID_CheckBox_AdjustZero">
                       <property name="text">
-                       <string>Shift NMR Signal</string>
+                       <string>Shift FID Signal</string>
                       </property>
                       <property name="checked">
                        <bool>false</bool>
@@ -5996,7 +5996,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                        <item>
                         <widget class="QDoubleSpinBox" name="RecFID_DoubleSpinBox_MseDivider">
                          <property name="prefix">
-                          <string>derive by </string>
+                          <string>divide by </string>
                          </property>
                          <property name="suffix">
                           <string/>

--- a/form.ui
+++ b/form.ui
@@ -5639,16 +5639,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="RecFID_CheckBox_AdjustFrequencyPhase">
-                      <property name="text">
-                       <string>Adjust Frequency/Phase</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
                      <widget class="QCheckBox" name="RecFID_CheckBox_TimeDomainApodization">
                       <property name="text">
                        <string>TD Apodization</string>

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -103,8 +103,6 @@ class MainWindow(QMainWindow):
         self.ui.DQTemp_Button_Save.clicked.connect(self.save_data)
         self.ui.T1T2_Button_Save.clicked.connect(self.save_data)
         self.ui.GS_Button_Save.clicked.connect(self.save_data)
-        if hasattr(self.ui, "pushButtonSaveRecFID"):
-            self.ui.pushButtonSaveRecFID.clicked.connect(self.save_data)
 
         self.ui.btn_Load.clicked.connect(self.load_data)
         self.ui.DQTemp_Button_Load.clicked.connect(self.load_data)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -18,7 +18,7 @@ from pyqtgraph import mkColor, mkPen
 from ui_Form import Ui_NMR
 from controllers import (
     SETabController, DQTabController, DQTempTabController,
-    T1T2TabController, DQMQTabController, GSTabController, GeneralSEDQController
+    T1T2TabController, DQMQTabController, GSTabController, GeneralSEDQController, RecFIDController
 )
 from dialogs.open_files_dialog import OpenFilesDialog
 import dialogs.open_files_dialog as open_files_dialog_module
@@ -87,6 +87,7 @@ class MainWindow(QMainWindow):
         self.t1t2_controller = T1T2TabController(ui=self.ui, state=self.app_state, parent=self)
         self.dqmq_controller = DQMQTabController(ui=self.ui, state=self.app_state, parent=self)
         self.gs_controller = GSTabController(ui=self.ui, state=self.app_state, parent=self)
+        self.recfid_controller = RecFIDController(ui=self.ui, state=self.app_state, parent=self)
         self.general_se_dq_controller = GeneralSEDQController(ui=self.ui, state=self.app_state, parent=self, se_controller=self.se_controller, dq_controller=self.dq_controller)
 
         self.state()
@@ -102,6 +103,8 @@ class MainWindow(QMainWindow):
         self.ui.DQTemp_Button_Save.clicked.connect(self.save_data)
         self.ui.T1T2_Button_Save.clicked.connect(self.save_data)
         self.ui.GS_Button_Save.clicked.connect(self.save_data)
+        if hasattr(self.ui, "pushButtonSaveRecFID"):
+            self.ui.pushButtonSaveRecFID.clicked.connect(self.save_data)
 
         self.ui.btn_Load.clicked.connect(self.load_data)
         self.ui.DQTemp_Button_Load.clicked.connect(self.load_data)
@@ -163,11 +166,13 @@ class MainWindow(QMainWindow):
         self.setup_graph(self.ui.GS_PlotWidget_RawSignal, "√Time, √us", "Signal", "")
         self.setup_graph(self.ui.GS_PlotWidget_SqrtTime, "X axis", "√Time, √us", "")
         self.setup_graph(self.ui.DQTemp_PlotWidget_PolyFit, "T₂*", "Norm. DQ Intensity", "PolyFit")
+        self.recfid_controller.initialize_plots()
         self.se_controller.connect_signals()
         self.dq_controller.connect_signals()
         self.dq_temp_controller.connect_signals()
         self.t1t2_controller.connect_signals()
         self.gs_controller.connect_signals()
+        self.recfid_controller.connect_signals()
 
         # Table Headers
         self.copy_enabler = TableCopyEnabler(self)
@@ -641,9 +646,13 @@ class MainWindow(QMainWindow):
 
     def state(self):
         """Update the cached tab name when the user changes tabs."""
-        current_tab_index =  self.ui.tabWidget.currentIndex()
+        current_tab_index = self.ui.tabWidget.currentIndex()
+        current_widget = self.ui.tabWidget.currentWidget()
+        current_name = current_widget.objectName() if current_widget is not None else ""
 
-        if current_tab_index == 0:
+        if current_name == "g_RecFID":
+            self.tab = 'RecFID'
+        elif current_tab_index == 0:
             self.tab = 'SE'
         elif current_tab_index == 1:
             self.tab = 'DQ'
@@ -873,6 +882,10 @@ class MainWindow(QMainWindow):
                     QMessageBox.Ok,
                 )
                 return
+
+        elif self.tab == 'RecFID':
+            self.recfid_controller.save_results()
+            return
 
         dialog = SaveFilesDialog(self)
         dialog.save_data_as_csv(self, table, files, default_name)

--- a/plotmat/plot_interactive_Dres.py
+++ b/plotmat/plot_interactive_Dres.py
@@ -1,11 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, RadioButtons
-
-try:
-    trapz = np.trapezoid
-except AttributeError:
-    trapz = np.trapz
+from scipy.integrate import trapezoid as trapz
 
 # -----------------------------
 # Constants / grid


### PR DESCRIPTION
### Motivation
- Migrate the legacy Build‑up FID / RecFID functionality into the new main application tab `g_RecFID` while following the app architecture (controller, pure calculations, dialogs) and preserving existing workflows (file loading, SE extrapolation, FID build‑up, manual echo assignment, exports).
- Keep numerical logic separated from UI code and avoid copying the old standalone GUI into `MainWindow`.

### Description
- Added a new controller `RecFIDController` in `controllers/recfid_controller.py` that owns file selection, validation, orchestration of analysis (`compare`, `extrapolate`, `build_up`, `rebuild`), plotting, manual echo‑time dialog, and save/export operations; it is instantiated and signal‑connected from `MainWindow` and exported via `controllers/__init__.py`.
- Implemented a pure numerical module `calculations/recfid_signal.py` containing cleaned and reorganized functions from the old `BuildUpFIDExternal/Math.py` (reading data, phase/frequency corrections, apodization, `calculate_M2` using `np.trapezoid`, `find_maximum_se`, `build_up_fid`, `analyze_build_up`, helpers and `AnalysisOptions`/`SignalAnalysisResult`).
- Introduced RecFID dialogs in `dialogs/recfid_dialogs.py` for manual echo‑time assignment (`RecFIDManualEchoTimeDialog`) and optional time‑range T2 map visualization/export (`RecFIDTimeAnalysisDialog`) so UI jobs remain outside calculations.
- Wired `MainWindow` to instantiate and initialize the `RecFIDController`, initialize the `g_RecFID` plots, detect the `g_RecFID` tab by object name, and route RecFID save requests to `RecFIDController.save_results()`; added a small `busy_cursor` helper used by the controller for long operations.

### Testing
- Compiled modules with `python3 -m compileall calculations/recfid_signal.py dialogs/recfid_dialogs.py controllers/recfid_controller.py mainwindow.py`, which succeeded without syntax errors.
- Performed a short smoke attempt to exercise numeric helpers (`freq_domain_correction`, `calculate_M2`, `build_up_fid`), but the runtime check failed due to missing runtime `numpy` in the ephemeral environment (`ModuleNotFoundError: No module named 'numpy'`), so numerical correctness was not validated end‑to‑end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf9e13c588327a328f02aede4c9ee)