### PR TITLE
Add shared status bar messaging and unify footer notifications

### DIFF
--- a/controllers/base_tab_controller.py
+++ b/controllers/base_tab_controller.py
@@ -1,8 +1,26 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 class BaseTabController:
     def __init__(self, ui, state, parent=None):
         self.ui = ui
         self.state = state
         self.parent = parent
+
+    def show_status(self, message, timeout=8000):
+        """Show a concise user-facing footer/status-bar message and log it."""
+        if self.parent is not None and hasattr(self.parent, "show_status"):
+            self.parent.show_status(message, timeout=timeout)
+            return
+        if self.parent is not None and hasattr(self.parent, "statusBar"):
+            self.parent.statusBar().showMessage(message, timeout)
+        logger.info(message)
+
+    def _status(self, message, timeout=8000):
+        """Backward-compatible alias for controllers that used the RecFID helper."""
+        self.show_status(message, timeout=timeout)
 
     def read_column_values(self, table, column):
         values = []

--- a/controllers/dq_controller.py
+++ b/controllers/dq_controller.py
@@ -34,6 +34,7 @@ class DQTabController(BaseTabController):
         if not self._has_table_data("Cannot update DQ plot because the table is empty."):
             return
 
+        self._status("Updating DQ plot...")
         self.update_graphs(show_warning=True)
 
     def update_graphs(self, show_warning=False):
@@ -75,6 +76,8 @@ class DQTabController(BaseTabController):
             symbolSize=10,
         )
         self.highlight_selected_point_widget_1()
+        if show_warning:
+            self._status("Plot updated.")
 
     def linearization(self, show_warning=False):
         if not self._has_table_data("No DQ data available. Load or analyze DQ files first.", show_warning):
@@ -97,6 +100,7 @@ class DQTabController(BaseTabController):
         )
         if result is None:
             if show_warning:
+                self._status("Could not fit DQ data: invalid range.")
                 QMessageBox.warning(
                     self.parent,
                     "Invalid DQ range",
@@ -127,6 +131,8 @@ class DQTabController(BaseTabController):
         self.dq_t2_graph(show_warning=False)
         self.ui.DQ_PlotWidget_T2.plot(result["x_line"], result["y_line"], pen="r")
         self.t2_dq_graph(show_warning=False)
+        if show_warning:
+            self._status("DQ linearization completed.")
         return True
 
     def t2_dq_graph(self, show_warning=False):
@@ -154,6 +160,8 @@ class DQTabController(BaseTabController):
             symbolSize=10,
         )
         self.highlight_selected_point_widget_2()
+        if show_warning:
+            self._status("Plot updated.")
 
     def plot_fit_from_user(self):
         self.plot_fit(show_warning=True)
@@ -176,6 +184,7 @@ class DQTabController(BaseTabController):
         fit_function = self.ui.DQ_ComboBox_FitFunction.currentText()
         if not fit_function:
             if show_warning:
+                self._status("Select a DQ fit function first.")
                 QMessageBox.warning(
                     self.parent,
                     "No DQ fit function",
@@ -193,6 +202,7 @@ class DQTabController(BaseTabController):
             )
         except (RuntimeError, ValueError, TypeError):
             if show_warning:
+                self._status("Could not fit DQ data: non-numeric values.")
                 QMessageBox.warning(
                     self.parent,
                     "DQ fit error",
@@ -213,6 +223,8 @@ class DQTabController(BaseTabController):
             f"FWHM: {round(result['fwhm'], 4)} \n"
             f"Fraction (Lorenz): {round(result['lorenz_fraction'], 2)}"
         )
+        if show_warning:
+            self._status("Fit completed.")
 
     def highlight_selected_point_widget_1(self):
         row = self.ui.DQ_Table_Data.currentRow()
@@ -288,6 +300,7 @@ class DQTabController(BaseTabController):
             return True
 
         if show_warning:
+            self._status("Could not fit DQ data: missing columns.")
             QMessageBox.warning(
                 self.parent,
                 "No DQ fit data",
@@ -301,6 +314,7 @@ class DQTabController(BaseTabController):
             return self.read_column_values(self.ui.DQ_Table_Data, column_index)
         except (ValueError, TypeError, IndexError):
             if show_warning:
+                self._status("Could not fit DQ data: non-numeric values.")
                 QMessageBox.warning(
                     self.parent,
                     "Invalid DQ data",
@@ -310,4 +324,5 @@ class DQTabController(BaseTabController):
             return None
 
     def _warn_no_data(self, message):
+        self._status(message)
         QMessageBox.warning(self.parent, "No DQ data", message, QMessageBox.Ok)

--- a/controllers/dq_temp_controller.py
+++ b/controllers/dq_temp_controller.py
@@ -26,6 +26,7 @@ class DQTempTabController(BaseTabController):
             self._warn_no_data("No DQ temperature data available. Select DQ comparison files first.")
             return
 
+        self._status(f"Loading {len(self.parent.selected_DQfiles)} DQ temperature file(s)...")
         with busy_cursor():
             table = self.ui.DQTemp_Table_Results
             valid_files = []
@@ -66,8 +67,10 @@ class DQTempTabController(BaseTabController):
 
             if not valid_files:
                 self._clear_plots()
+                self._status("Could not load DQ temperature files.")
                 return
 
+            self._status(f"Loaded {len(valid_files)} DQ temperature file(s).")
             self.launch()
 
     def launch(self):
@@ -75,6 +78,7 @@ class DQTempTabController(BaseTabController):
             self._warn_no_data("No DQ temperature data available. Select DQ comparison files first.")
             return
 
+        self._status("Fitting DQ temperature data...")
         logger.info("DQ Temp launching comparison fit")
         self.parent.dq_t2 = {}
         failed_files = []
@@ -94,6 +98,8 @@ class DQTempTabController(BaseTabController):
                 "Some DQ temperature files could not be fitted. They were filled with NaN.",
                 all_failed_files,
             )
+        else:
+            self._status("Fit completed.")
 
     def update_DQ_comparison_plot(self, show_warning=True):
         table = self.ui.DQTemp_Table_Results
@@ -175,6 +181,8 @@ class DQTempTabController(BaseTabController):
 
         table.resizeColumnsToContents()
         self._plot_centers(comparison_axis, center_gauss, center_lorenz, center_voigt, center_derivative)
+        if show_warning:
+            self._status("Plot updated.")
 
         if failed_files and show_warning:
             self._warn_failed_files(
@@ -293,6 +301,7 @@ class DQTempTabController(BaseTabController):
         self.ui.DQTemp_PlotWidget_PolyFit.clear()
 
     def _warn_no_data(self, message):
+        self._status(message)
         QMessageBox.warning(self.parent, "No DQ temperature data", message, QMessageBox.Ok)
 
     def _warn_failed_files(self, message, failed_files):
@@ -300,6 +309,7 @@ class DQTempTabController(BaseTabController):
         if len(failed_files) > 5:
             preview += f"\n...and {len(failed_files) - 5} more"
 
+        self._status(message)
         QMessageBox.warning(
             self.parent,
             "DQ temperature processing warning",

--- a/controllers/dqmq_controller.py
+++ b/controllers/dqmq_controller.py
@@ -135,6 +135,7 @@ class DQMQTabController(BaseTabController):
     def _ensure_raw_data(self):
         file_path = self._get_current_file()
         if file_path is None:
+            self._status("Select a DQMQ file first.")
             QMessageBox.warning(
                 self.parent,
                 "DQMQ file missing",
@@ -184,9 +185,11 @@ class DQMQTabController(BaseTabController):
 
     def dq_mq_analysis(self):
         with busy_cursor():
+            self._status("Loading DQMQ data...")
             logger.info("DQMQ raw load started")
             file_path = self._get_current_file()
             if file_path is None:
+                self._status("Select a DQMQ file first.")
                 QMessageBox.warning(
                     self.parent,
                     "DQMQ file missing",
@@ -199,6 +202,7 @@ class DQMQTabController(BaseTabController):
                 raw_data = self._read_raw_data_from_file(file_path)
             except Exception as exc:
                 logger.exception("DQMQ raw load failed")
+                self._status(f"Could not process file: {exc}")
                 QMessageBox.warning(
                     self.parent,
                     "Corrupt File",
@@ -214,6 +218,7 @@ class DQMQTabController(BaseTabController):
             # self._enable_file_actions()
             self.render_raw_plot()
             logger.info("DQMQ raw load completed: %d points", len(raw_data["time"]))
+            self._status("Loaded DQMQ data.")
 
     def render_raw_plot(self):
         raw_data = self._ensure_raw_data()
@@ -244,7 +249,9 @@ class DQMQTabController(BaseTabController):
         return time, dq, ref
 
     def plot_original(self):
-        return self.render_raw_plot()
+        result = self.render_raw_plot()
+        self._status("Plot updated.")
+        return result
 
     def _analysis_parameters(self):
         fit_from = self.ui.DQMQ_DoubleSpinBox_FitFrom.value()
@@ -263,6 +270,7 @@ class DQMQTabController(BaseTabController):
         raw_data = self._ensure_raw_data()
         if raw_data is None:
             return None
+        self._status("Running DQMQ analysis...")
 
         if self.ui.DQMQ_Table_Data.rowCount() != len(raw_data["time"]):
             self._write_raw_table(raw_data)
@@ -295,6 +303,7 @@ class DQMQTabController(BaseTabController):
                 )
         except Exception as exc:
             logger.exception("DQMQ full analysis failed")
+            self._status(f"Could not run DQMQ analysis: {exc}")
             QMessageBox.warning(self.parent, "DQMQ analysis failed", str(exc))
             return None
 
@@ -304,6 +313,7 @@ class DQMQTabController(BaseTabController):
         )
         self.dres_is_stale = True
         self.render_analysis_plot()
+        self._status("Fit completed.")
         return self.analysis_result
 
     def plot_norm(self):
@@ -326,6 +336,7 @@ class DQMQTabController(BaseTabController):
             return
         if self.current_plot_mode == "analysis":
             self.render_analysis_plot()
+            self._status("Plot updated.")
 
     def _dqmq_pen(self, style_name, *, dashed=False):
         style = DQMQ_PLOT_STYLES[style_name]
@@ -486,10 +497,13 @@ class DQMQTabController(BaseTabController):
                 }
                 if self.current_plot_mode == "analysis":
                     self.render_analysis_plot()
+                self._status("Calculated integral sum.")
         except ValueError as exc:
+            self._status(f"Could not process file: {exc}")
             QMessageBox.warning(self.parent, "Invalid file", str(exc))
         except Exception as exc:
             logger.exception("Integral sum calculation failed")
+            self._status(f"Could not calculate integral sum: {exc}")
             QMessageBox.warning(
                 self.parent, "Integral sum calculation failed", str(exc)
             )
@@ -546,6 +560,7 @@ class DQMQTabController(BaseTabController):
         self.integral_sum_result["time"] = self.integral_sum_result["time_base"] + shift
         if self.current_plot_mode == "analysis":
             self.render_analysis_plot()
+            self._status("Integral sum shift updated.")
 
     def save_integral_sum_result(self, base_file_path):
         if not self.integral_sum_result:
@@ -599,14 +614,17 @@ class DQMQTabController(BaseTabController):
                 self._plot_dres_distribution()
                 if self.current_plot_mode == "analysis":
                     self.render_analysis_plot()
+                self._status("Dres calculation completed.")
         except ValueError as exc:
             if show_errors:
+                self._status(f"Could not calculate Dres: {exc}")
                 QMessageBox.warning(self.parent, "Dres calculation", str(exc))
             else:
                 logger.warning("Skipping automatic Dres calculation: %s", exc)
         except Exception as exc:
             logger.exception("Dres calculation failed")
             if show_errors:
+                self._status(f"Could not calculate Dres: {exc}")
                 QMessageBox.warning(self.parent, "Dres calculation failed", str(exc))
 
     def _dres_input_arrays(self):
@@ -780,6 +798,7 @@ class DQMQTabController(BaseTabController):
     def mark_dres_stale(self):
         self.dres_is_stale = True
         logger.info("DQMQ Dres parameters changed; Dres result is stale")
+        self._status("Dres settings changed.")
 
     def _plot_dres_distribution(self):
         if not self.dres_result:

--- a/controllers/general_se_dq_controller.py
+++ b/controllers/general_se_dq_controller.py
@@ -37,8 +37,10 @@ class GeneralSEDQController(BaseTabController):
                 self.ui.DQ_ComboBox_FitFunction.setCurrentIndex(-1)
 
             if len(files) == 0:
+                self._status("Load data files first.")
                 return
 
+            self._status(f"Analyzing {len(files)} {mw.tab} file(s)...")
             logger.info("%s analysis started: %d files", mw.tab, len(files))
             logger.info(
                 "Options - glycerol:%s baseline:%s long_component:%s smoothing:%s",
@@ -90,11 +92,13 @@ class GeneralSEDQController(BaseTabController):
             self.update_legends_and_dq_graphs()
             self.ui.btn_Start.setStyleSheet("background-color: none")
             logger.info("%s analysis completed: %d files", mw.tab, len(files))
+            self._status("Analysis completed.")
 
     def analysis_error(self, file_path, files):
         logger.exception("Failed to process file %s", file_path)
 
         mw = self.parent
+        self._status(f"Could not process file: {os.path.basename(file_path)}")
         QMessageBox.warning(
             mw,
             "Invalid Data",
@@ -238,6 +242,7 @@ class GeneralSEDQController(BaseTabController):
             or self.state.spectrum.re_spectra is None
             or self.state.spectrum.im_spectra is None
         ):
+            self._status("Load data before opening manual phasing.")
             QMessageBox.warning(
             self.parent,
             "No spectrum data",
@@ -250,12 +255,15 @@ class GeneralSEDQController(BaseTabController):
         mw.phasing_manual_window.read_data()
         mw.phasing_manual_window.show()
         mw.phasing_manual_window.closed.connect(self.after_phasing)
+        self._status("Opened manual phasing.")
 
     def open_select_dialog_glycerol(self):
         dlg = OpenFilesDialog(self.parent)
         dlg.setWindowTitle("Select Glycerol Files")
         if dlg.exec():
-            self.parent.selected_files_gly.extend(dlg.selectedFiles())
+            files = dlg.selectedFiles()
+            self.parent.selected_files_gly.extend(files)
+            self._status(f"Loaded {len(files)} glycerol file(s).")
         # self.ui.btn_Start.setEnabled(True)
         # self.ui.btn_Add.setEnabled(True)
 
@@ -263,6 +271,8 @@ class GeneralSEDQController(BaseTabController):
         dlg = OpenFilesDialog(self.parent)
         dlg.setWindowTitle("Select Baseline Files")
         if dlg.exec():
-            self.parent.selected_files_empty.extend(dlg.selectedFiles())
+            files = dlg.selectedFiles()
+            self.parent.selected_files_empty.extend(files)
+            self._status(f"Loaded {len(files)} baseline file(s).")
         # self.ui.btn_Start.setEnabled(True)
         # self.ui.btn_Add.setEnabled(True)

--- a/controllers/gs_controller.py
+++ b/controllers/gs_controller.py
@@ -30,6 +30,8 @@ class GSTabController(BaseTabController):
         self.ui.GS_ComboBox_ChooseFile.activated.connect(lambda *_args: self.calculate_sqrt_time())
 
     def update_GS_table(self):
+        if self.parent.selected_GSfiles:
+            self._status(f"Loading {len(self.parent.selected_GSfiles)} spin diffusion file(s)...")
         with busy_cursor():
             self._update_GS_table_impl()
 
@@ -75,6 +77,10 @@ class GSTabController(BaseTabController):
 
         combobox.setCurrentIndex(-1)
         table.resizeColumnsToContents()
+        if table.rowCount():
+            self._status(f"Loaded {table.rowCount()} spin diffusion row(s).")
+        else:
+            self._status("Could not load spin diffusion files.")
 
     def _add_table_row(self, table, combobox, row, folder, file_name, x_axis):
         table.insertRow(row)
@@ -100,6 +106,7 @@ class GSTabController(BaseTabController):
 
         if idx == -1:
             if show_warning:
+                self._status("No rows selected.")
                 QMessageBox.warning(
                     self.parent,
                     "No spin diffusion row selected",
@@ -111,6 +118,7 @@ class GSTabController(BaseTabController):
         item = table.item(idx, GSColumns.FOLDER)
         if item is None or item.text() not in dictionary:
             if show_warning:
+                self._status("Could not fit spin diffusion data: non-numeric values.")
                 QMessageBox.warning(
                     self.parent,
                     "No spin diffusion data",
@@ -154,6 +162,7 @@ class GSTabController(BaseTabController):
         except Exception:
             logger.exception("GS fit failed: index=%d", idx)
             figure.clear()
+            self._status("Could not fit spin diffusion data.")
             QMessageBox.warning(
                 self.parent,
                 "Fitting failed",
@@ -180,6 +189,8 @@ class GSTabController(BaseTabController):
         dictionary_entry["sqrtT"] = sqrt_time
         dictionary_entry["d"] = diffusion_distance
         logger.info("GS fit completed: sqrtT=%s d=%s", sqrt_time, diffusion_distance)
+        if show_warning:
+            self._status("Fit completed.")
 
     def _update_fit_limits(self, time_original):
         self.ui.GS_DoubleSpinBox_FitFrom.setMinimum(time_original[0])
@@ -205,6 +216,7 @@ class GSTabController(BaseTabController):
 
         if table.rowCount() < 1:
             if show_warning:
+                self._status("Cannot update spin diffusion plot because the table is empty.")
                 QMessageBox.warning(
                     self.parent,
                     "No spin diffusion data",
@@ -236,6 +248,7 @@ class GSTabController(BaseTabController):
             fallback_x_axis += 1
 
         if invalid_result_count == table.rowCount() and show_warning:
+            self._status("Could not plot spin diffusion data: non-numeric values.")
             QMessageBox.warning(
                 self.parent,
                 "No spin diffusion data",
@@ -253,11 +266,15 @@ class GSTabController(BaseTabController):
             symbolBrush="r",
             symbolSize=10,
         )
+        if show_warning:
+            self._status("Plot updated.")
 
     def _warn_no_data(self, message):
+        self._status(message)
         QMessageBox.warning(self.parent, "No spin diffusion data", message, QMessageBox.Ok)
 
     def _warn_invalid_range(self):
+        self._status("Could not fit spin diffusion data: invalid range.")
         QMessageBox.warning(
             self.parent,
             "Invalid spin diffusion range",
@@ -269,4 +286,5 @@ class GSTabController(BaseTabController):
         preview = "\n".join(failed_files[:5])
         if len(failed_files) > 5:
             preview += f"\n...and {len(failed_files) - 5} more"
+        self._status(message)
         QMessageBox.warning(self.parent, "Spin diffusion load warning", f"{message}\n\n{preview}", QMessageBox.Ok)

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -713,9 +713,5 @@ class RecFIDController(BaseTabController):
         return widget.currentText() if widget is not None else default
 
     def _warn(self, title, message):
+        self._status(message)
         QMessageBox.warning(self.parent, title, message, QMessageBox.Ok)
-
-    def _status(self, message):
-        if self.parent is not None and hasattr(self.parent, "statusBar"):
-            self.parent.statusBar().showMessage(message, 8000)
-        logger.info(message)

--- a/controllers/se_controller.py
+++ b/controllers/se_controller.py
@@ -51,6 +51,7 @@ class SETabController(BaseTabController):
 
     def update_graphs_from_user(self):
         if self.ui.SE_Table_Data.rowCount() == 0:
+            self._status("No SE data available.")
             QMessageBox.warning(
                 self.parent,
                 "No SE data",
@@ -85,6 +86,7 @@ class SETabController(BaseTabController):
             self.ui.SE_PlotWidget_Main.getAxis("left").setLabel("T₂*")
         else:
             self.ui.SE_PlotWidget_Main.getAxis("left").setLabel("Not Set")
+            self._status("Cannot update SE plot: selected Y column is missing.")
             QMessageBox.warning(
                 self.parent,
                 "SE plot unavailable",
@@ -144,6 +146,7 @@ class SETabController(BaseTabController):
         graph = self.ui.SE_PlotWidget_Main
 
         if table.rowCount() == 0:
+            self._status("No SE data available.")
             QMessageBox.warning(
                 self.parent,
                 "No SE data",
@@ -198,7 +201,9 @@ class SETabController(BaseTabController):
             graph.plot(temp_fit, fitted_curve, pen="b")
             self.parent.setup_graph(graph, "1000/T, 𝐾⁻¹", "ln(τ)", "")
             self.ui.SE_TextEdit_EActResult.setText(f"Eact = {eact}\nR² {r2}")
+            self._status("Fit completed.")
         except Exception as exc:
+            self._status(f"Could not fit Arrhenius plot: {exc}")
             QMessageBox.warning(self.parent, "Arrhenius fit error", str(exc), QMessageBox.Ok)
 
     def hide_Eact(self):
@@ -206,10 +211,12 @@ class SETabController(BaseTabController):
         self.ui.SE_PlotWidget_Main.clear()
         self.parent.setup_graph(self.ui.SE_PlotWidget_Main, "", "", "")
         self.parent.update_xaxis(self.ui.SE_Table_Data, 0)
+        self._status("Activation energy view closed.")
 
     def open_group_window(self):
         table = self.ui.SE_Table_Data
         if table.rowCount() == 0:
+            self._status("No SE data available.")
             QMessageBox.warning(
                 self.parent,
                 "No SE data",
@@ -227,6 +234,7 @@ class SETabController(BaseTabController):
 
         self.parent.group_data_SE = group_window.group_dict
         self.update_graphs()
+        self._status("Updated SE groups.")
 
     def highlight_selected_point(self):
         row = self.ui.SE_Table_Data.currentRow()

--- a/controllers/t1t2_controller.py
+++ b/controllers/t1t2_controller.py
@@ -35,6 +35,8 @@ class T1T2TabController(BaseTabController):
         )
 
     def update_T12_table(self):
+        if self.parent.selected_T1files:
+            self._status(f"Loading {len(self.parent.selected_T1files)} T1/T2 file(s)...")
         with busy_cursor():
             self._update_T12_table_impl()
 
@@ -46,6 +48,7 @@ class T1T2TabController(BaseTabController):
 
         legacy_files = [path for path in selected_files if path.lower().endswith(".sef")]
         if legacy_files:
+            self._status("Unsupported T1/T2 file skipped.")
             QMessageBox.warning(
                 self.parent,
                 "Unsupported T1/T2 file",
@@ -79,6 +82,11 @@ class T1T2TabController(BaseTabController):
 
         combobox.setCurrentIndex(-1)
         table.resizeColumnsToContents()
+        loaded_count = table.rowCount()
+        if loaded_count:
+            self._status(f"Loaded {loaded_count} T1/T2 row(s).")
+        else:
+            self._status("Could not load T1/T2 files.")
 
     def _load_csv_files(self, table, combobox, dictionary, preserved_x_axis, selected_files):
         logger.info("T1T2 branch: CSV")
@@ -256,12 +264,14 @@ class T1T2TabController(BaseTabController):
 
         if idx == -1:
             if show_warning:
+                self._status("No rows selected.")
                 QMessageBox.warning(self.parent, "No T1/T2 row selected", "No T1/T2 row selected.", QMessageBox.Ok)
             return
 
         item = table.item(idx, T1Columns.FOLDER)
         if item is None or item.text() not in dictionary:
             if show_warning:
+                self._status("Could not fit T1/T2 data: non-numeric values.")
                 QMessageBox.warning(
                     self.parent,
                     "No T1/T2 data",
@@ -296,6 +306,7 @@ class T1T2TabController(BaseTabController):
             initial_params = t1t2_signal.initial_parameters(order, fit_signal, tau1, tau2, tau3)
         except ValueError:
             if show_warning:
+                self._status("Could not fit T1/T2 data: invalid range.")
                 QMessageBox.warning(
                     self.parent,
                     "Invalid T1/T2 range",
@@ -314,6 +325,7 @@ class T1T2TabController(BaseTabController):
             )
         except Exception:
             logger.exception("T1T2 fit failed for index=%d order=%d", idx, order)
+            self._status("Could not fit T1/T2 data.")
             QMessageBox.warning(
                 self.parent,
                 "Fitting failed",
@@ -323,6 +335,8 @@ class T1T2TabController(BaseTabController):
             return
 
         logger.info("T1T2 fit completed: tau1=%s tau2=%s tau3=%s r2=%s", tau_1, tau_2, tau_3, r2)
+        if show_warning:
+            self._status("Fit completed.")
         self.ui.T1T2_TextEdit_FitResult.setText(f"R² {r2}")
         table.setItem(idx, T1Columns.TAU_1, QTableWidgetItem(str(tau_1)))
         table.setItem(idx, T1Columns.TAU_2, QTableWidgetItem(str(tau_2)))
@@ -369,6 +383,8 @@ class T1T2TabController(BaseTabController):
 
         graph.plot(x_axis, relaxation_time, pen=None, symbolPen=None, symbol="o", symbolBrush="r", symbolSize=10)
         self.highlight_selected_relaxation_point()
+        if show_warning:
+            self._status("Plot updated.")
 
     def highlight_selected_relaxation_point(self):
         row = self.ui.T1T2_Table_Results.currentRow()
@@ -405,10 +421,12 @@ class T1T2TabController(BaseTabController):
         return T1Columns.TAU_3
 
     def _warn_no_data(self, message):
+        self._status(message)
         QMessageBox.warning(self.parent, "No T1/T2 data", message, QMessageBox.Ok)
 
     def _warn_failed_files(self, message, failed_files):
         preview = "\n".join(failed_files[:5])
         if len(failed_files) > 5:
             preview += f"\n...and {len(failed_files) - 5} more"
+        self._status(message)
         QMessageBox.warning(self.parent, "T1/T2 load warning", f"{message}\n\n{preview}", QMessageBox.Ok)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -186,6 +186,8 @@ class MainWindow(QMainWindow):
         self.disable_buttons()
         self.ui.SE_GroupBox_EAct.setHidden(True)
 
+        self.show_status("Ready.")
+
         self.tab10_colors = [
             mkColor('#1f77b4'),  # blue
             mkColor('#ff7f0e'),  # orange
@@ -198,6 +200,11 @@ class MainWindow(QMainWindow):
             mkColor('#bcbd22'),  # olive
             mkColor('#17becf')   # cyan
         ]
+
+    def show_status(self, message, timeout=8000):
+        """Show a concise user-facing footer/status-bar message and log it."""
+        self.statusBar().showMessage(message, timeout)
+        logger.info(message)
 
     def check_for_updates(self):
         """Check GitHub releases and prompt when a newer app version exists."""
@@ -222,10 +229,12 @@ class MainWindow(QMainWindow):
 
         except requests.RequestException as e:
             logger.warning("Failed to check for updates: %s", e)
+            self.show_status("Could not check for updates.")
 
     def open_url(self):
         """Open the GitHub releases page used by the Settings tab."""
         open_application('https://github.com/timesama/M2-Approach/releases')
+        self.show_status("Opened project releases page.")
 
     def open_interactive_dres_tool(self):
         """Open or raise the standalone interactive Dres matplotlib tool."""
@@ -237,6 +246,7 @@ class MainWindow(QMainWindow):
                 and plt.fignum_exists(self.interactive_dres_figure.number)
             ):
                 self._raise_interactive_dres_window(self.interactive_dres_figure)
+                self.show_status("Interactive Dres tool is already open.")
                 return
 
             from plotmat import plot_interactive_Dres as interactive_dres
@@ -246,9 +256,11 @@ class MainWindow(QMainWindow):
                 "close_event",
                 self._clear_interactive_dres_reference,
             )
+            self.show_status("Opened interactive Dres tool.")
         except Exception:
             logger.exception("Could not open the interactive Dres tool.")
             self.interactive_dres_figure = None
+            self.show_status("Could not open interactive Dres tool.")
             QMessageBox.warning(
                 self,
                 "Interactive Dres",
@@ -285,8 +297,9 @@ class MainWindow(QMainWindow):
 
         try:
             file_path = next((f for f in files if os.path.basename(f) == filename), None)
-            i = next((i for i, f in enumerate(files) if os.path.basename(f) == filename), None)+1
-        except:
+            i = next((i for i, f in enumerate(files) if os.path.basename(f) == filename), None) + 1
+        except Exception:
+            self.show_status("Could not find the selected file.")
             return
 
         if self.ui.Settings_CheckBox_Glycerol.isChecked() and self.ui.Settings_CheckBox_Baseline.isChecked():
@@ -312,7 +325,11 @@ class MainWindow(QMainWindow):
         try:
             self.general_se_dq_controller.process_file_data(file_path, file_path_gly, file_path_empty, i)
         except Exception:
+            logger.exception("Could not update file preview: %s", filename)
+            self.show_status(f"Could not process file: {filename}")
             return
+
+        self.show_status(f"Loaded preview for {filename}.")
 
         if self.tab == 'DQ':
             self.highlight_row(self.ui.DQ_Table_Data, i)
@@ -390,6 +407,7 @@ class MainWindow(QMainWindow):
                 combobox.removeItem(0)
 
         self.window_array = np.array([])
+        self.show_status(f"Cleared {self.tab} data.")
 
     def delete_row(self):
         """Delete the selected row and keep the active tab file list in sync."""
@@ -427,6 +445,7 @@ class MainWindow(QMainWindow):
                 )
             else:
                 QMessageBox.warning(self, "Cricket sounds", "Select the row.", QMessageBox.Ok)
+            self.show_status("No rows selected.")
             return
 
         table.removeRow(row)
@@ -441,6 +460,8 @@ class MainWindow(QMainWindow):
             if self.tab in ('SE', 'DQ') and self.selected_files_empty and len(self.selected_files_empty) > row:
                 self.selected_files_empty.pop(row)
         except Exception:
+            logger.exception("File list sync failed after deleting row")
+            self.show_status("Deleted row, but file list may be out of sync.")
             QMessageBox.warning(self, "Delete warning", "Row was removed from table, but file lists may be out of sync.", QMessageBox.Ok)
 
         if self.tab == 'SE':
@@ -454,6 +475,8 @@ class MainWindow(QMainWindow):
         elif self.tab in ('SE', 'DQ'):
             self.ui.FidWidget.clear()
             self.ui.FFTWidget.clear()
+
+        self.show_status("Deleted selected row.")
 
     def highlight_row(self, table, row_selected):
 
@@ -489,38 +512,45 @@ class MainWindow(QMainWindow):
             if self.tab == 'DQ_Temp':
                 DQfileNames = dlg.selectedFiles()
                 self.selected_DQfiles.extend(DQfileNames)
+                self.show_status(f"Loaded {len(DQfileNames)} DQ temperature file(s).")
                 self.dq_temp_controller.update_DQ_comparison()
             elif self.tab == 'T1T2':
                 while self.ui.T1T2_ComboBox_ChooseFile.count()>0:
                     self.ui.T1T2_ComboBox_ChooseFile.removeItem(0)
                 T1fileNames = dlg.selectedFiles()
                 self.selected_T1files.extend(T1fileNames)
+                self.show_status(f"Loaded {len(T1fileNames)} T1/T2 file(s).")
                 self.t1t2_controller.update_T12_table()
             elif self.tab == 'GS':
                 while self.ui.GS_ComboBox_ChooseFile.count() > 0:
                     self.ui.GS_ComboBox_ChooseFile.removeItem(0)
                 GSfileNames = dlg.selectedFiles()
                 self.selected_GSfiles.extend(GSfileNames)
+                self.show_status(f"Loaded {len(GSfileNames)} spin diffusion file(s).")
                 self.gs_controller.update_GS_table()
             elif self.tab == 'DQMQ':
                 self.selected_DQMQfile = dlg.selectedFiles()
                 self.app_state.dqmq_files = self.selected_DQMQfile
                 self.dqmq_controller.state.dqmq_files = self.selected_DQMQfile
+                self.show_status("Loaded DQMQ file.")
                 self.dqmq_controller.dq_mq_analysis()
 
     def open_select_dialog(self):
         """Open the primary SE/DQ file picker."""
         open_files_dialog_module.State_multiple_files = True
         dlg = OpenFilesDialog(self)
+        files = []
 
         if dlg.exec():
             self.clear_list()
-            files = []
             fileNames = dlg.selectedFiles()
             files.extend(fileNames)
             # self.ui.btn_Start.setEnabled(True)
             self.ui.btn_Start.setStyleSheet("background-color: green")
+            self.show_status(f"Loaded {len(files)} file(s).")
             # self.ui.btn_Add.setEnabled(True)
+        else:
+            self.show_status("File loading cancelled.")
 
         if self.tab == 'SE':
             self.selected_files = files
@@ -543,7 +573,10 @@ class MainWindow(QMainWindow):
             files.extend(fileNames)
             # self.ui.btn_Start.setEnabled(True)
             self.ui.btn_Start.setStyleSheet("background-color: green")
+            self.show_status(f"Added {len(fileNames)} file(s).")
             # self.ui.btn_Add.setEnabled(True)
+        else:
+            self.show_status("File loading cancelled.")
 
         if self.tab == 'SE':
             self.selected_files = files
@@ -560,6 +593,7 @@ class MainWindow(QMainWindow):
             self.group_data_SE = {}
         elif self.tab == 'T1T2':
             if self.ui.T1T2_Table_Results.rowCount() == 0:
+                self.show_status("No T1/T2 data available.")
                 QMessageBox.warning(
                     self,
                     "No T1/T2 data",
@@ -571,6 +605,7 @@ class MainWindow(QMainWindow):
             self.group_data_T1T2 = {}
         elif self.tab == 'GS':
             if self.ui.GS_Table_Results.rowCount() == 0:
+                self.show_status("No spin diffusion data available.")
                 QMessageBox.warning(
                     self,
                     "No spin diffusion data",
@@ -585,19 +620,23 @@ class MainWindow(QMainWindow):
             data = self.group_window.group_dict
         else:
             logger.info("Group window was cancelled.")
+            self.show_status("Grouping cancelled.")
             return
 
         if self.tab == 'SE':
             self.group_data_SE = data
             self.update_se_graphs()
+            self.show_status("Updated SE groups.")
 
         elif self.tab == 'T1T2':
             self.group_data_T1T2 = data
             self.t1t2_controller.plot_relaxation_time()
+            self.show_status("Updated T1/T2 groups.")
 
         elif self.tab == 'GS':
             self.group_data_SD = data
             self.gs_controller.plot_sqrt_time()
+            self.show_status("Updated spin diffusion groups.")
 
 
     def _connect_dqmq_workflow_signals(self):
@@ -747,8 +786,10 @@ class MainWindow(QMainWindow):
                 winreg.SetValueEx(key, "SelectedFolder", 0, winreg.REG_SZ, folder_path)
                 winreg.CloseKey(key)
                 logger.info("Default folder saved to registry: %s", folder_path)
+                self.show_status("Saved default folder.")
             except Exception as e:
                 logger.warning("Failed to save the default folder to the registry: %s", e)
+                self.show_status("Could not save default folder.")
 
     def renameSection(self, table, index):
         """Rename a table header and mirror it to the linked x-axis label."""
@@ -758,6 +799,7 @@ class MainWindow(QMainWindow):
         if ok and new_header:
             table.horizontalHeaderItem(index).setText(new_header)
             self.update_xaxis(table, index)
+            self.show_status("Renamed table column.")
 
     def update_xaxis(self, table, index):
         """Update the active comparison plot x-axis label from a table header."""
@@ -774,6 +816,7 @@ class MainWindow(QMainWindow):
 
         name = table.horizontalHeaderItem(index).text()
         figure.getAxis('bottom').setLabel(name)
+        self.show_status("Updated plot axis.")
 
     def _apply_table_header_order(self):
         """Restore table headers that Qt Designer does not keep in controller order."""
@@ -849,8 +892,8 @@ class MainWindow(QMainWindow):
         if self.tab == 'SE':
             table = self.ui.SE_Table_Data
             files = self.selected_files
-            default_name = os.path.split(os.path.dirname(files[0]))[1] + '_SE_MSE_FID'
             if table.rowCount() == 0 or not files:
+                self.show_status("Load data files first.")
                 QMessageBox.warning(
                     self,
                     "No data loaded",
@@ -858,12 +901,13 @@ class MainWindow(QMainWindow):
                     QMessageBox.Ok,
                 )
                 return
+            default_name = os.path.split(os.path.dirname(files[0]))[1] + '_SE_MSE_FID'
 
         elif self.tab == 'DQ':
             table = self.ui.DQ_Table_Data
             files = self.selected_files_DQ_single
-            default_name = 'Table_DQ_' + os.path.split(os.path.dirname(files[0]))[1]
             if table.rowCount() == 0 or not files:
+                self.show_status("Load DQ data files first.")
                 QMessageBox.warning(
                     self,
                     "No DQ data loaded",
@@ -871,11 +915,13 @@ class MainWindow(QMainWindow):
                     QMessageBox.Ok,
                 )
                 return
+            default_name = 'Table_DQ_' + os.path.split(os.path.dirname(files[0]))[1]
 
         elif self.tab == 'DQ_Temp':
             table = self.ui.DQTemp_Table_Results
             files = self.selected_DQfiles
             if table.rowCount() == 0 or not files:
+                self.show_status("Load DQ comparison files first.")
                 QMessageBox.warning(
                     self,
                     "No DQ data",
@@ -892,6 +938,7 @@ class MainWindow(QMainWindow):
             table = self.ui.T1T2_Table_Results
             files = self.selected_T1files
             if table.rowCount() == 0 or not files:
+                self.show_status("Load T1/T2 files first.")
                 QMessageBox.warning(
                     self,
                     "No T1/T2 data",
@@ -905,6 +952,7 @@ class MainWindow(QMainWindow):
             table = self.ui.GS_Table_Results
             files = self.selected_GSfiles
             if table.rowCount() == 0 or not files:
+                self.show_status("Load spin diffusion files first.")
                 QMessageBox.warning(
                     self,
                     "No spin diffusion data",
@@ -918,9 +966,8 @@ class MainWindow(QMainWindow):
             table = self.ui.DQMQ_Table_Data
             files = self.selected_DQMQfile
 
-            default_name = os.path.split(os.path.dirname(files[0]))[1] + '_DQMQ_data'
-
             if table.rowCount() == 0 or not files:
+                self.show_status("Load DQMQ file first.")
                 QMessageBox.warning(
                     self,
                     "No DQMQ data",
@@ -929,11 +976,14 @@ class MainWindow(QMainWindow):
                 )
                 return
 
+            default_name = os.path.split(os.path.dirname(files[0]))[1] + '_DQMQ_data'
+
         elif self.tab == 'RecFID':
             self.recfid_controller.save_results()
             return
 
         dialog = SaveFilesDialog(self)
+        self.show_status("Saving analysis results...")
         dialog.save_data_as_csv(self, table, files, default_name)
 
         if self.tab == 'DQMQ' and dialog.last_saved_file_path:
@@ -947,6 +997,11 @@ class MainWindow(QMainWindow):
             with open(files_json, 'w') as f:
                 json.dump({"files": files, "phased": phased_data}, f)
 
+        if dialog.last_saved_file_path:
+            self.show_status("Saved analysis results.")
+        else:
+            self.show_status("Save cancelled.")
+
 
     def load_data(self):
         """Load a saved results table for the active tab."""
@@ -954,7 +1009,10 @@ class MainWindow(QMainWindow):
         # self.ui.btn_Save.setEnabled(False)
         if dlg.exec():
             tableName = dlg.selectedFiles()
+            self.show_status("Loading saved table...")
             self.load_table_from_csv(tableName)
+        else:
+            self.show_status("File loading cancelled.")
 
     def load_table_from_csv(self, tableName):
         with busy_cursor():
@@ -979,8 +1037,10 @@ class MainWindow(QMainWindow):
                     files = files_payload
                     phased = {}
         except Exception as e:
+            logger.warning("Saved table file list missing: %s", e)
+            self.show_status("Loaded table without file list.")
             QMessageBox.warning(self, "File missing", f"Didn't find file list, only the tabular result is available", QMessageBox.Ok)
-            files = None
+            files = []
             phased = {}
             # self.ui.comboBox_4.setEnabled(False)
             # self.ui.btn_Phasing.setEnabled(False)
@@ -1019,6 +1079,7 @@ class MainWindow(QMainWindow):
             lines = f.readlines()
             if self._is_probably_old_table_format(lines):
                 self._warn_old_table_format()
+                self.show_status("Old saved file format detected.")
                 return
             table.setRowCount(len(lines))
             for row, line in enumerate(lines):
@@ -1060,8 +1121,11 @@ class MainWindow(QMainWindow):
         elif self.tab == 'GS':
             self.gs_controller.update_GS_table()
 
+        self.show_status(f"Loaded saved {self.tab} table.")
+
     def _warn_old_table_format(self):
         """Warn when a saved table appears to use an obsolete column order."""
+        self.show_status("Old saved file format detected.")
         QMessageBox.warning(
             self,
             "Old saved file format",


### PR DESCRIPTION
### Motivation
- Provide a single, consistent footer/status-bar API across the app so all tabs/controllers report concise user-facing messages in a uniform style instead of duplicating status-bar logic. 
- Reuse the existing RecFID-style `_status(...)` behaviour so existing callers remain backward-compatible while consolidating presentation and logging.

### Description
- Introduced `BaseTabController.show_status(...)` with a backward-compatible `_status(...)` alias and added `MainWindow.show_status(...)`, routing controller status calls to the central method and preserving developer `logger` calls. 
- Added concise user-facing footer messages at key points (file loading / adding / cancel, save/export, table updates, plotting, fitting/analysis start and completion, import/export, recoverable warnings, and long-running operations) and kept modal `QMessageBox` usage for real errors only. 
- Changes were applied across these files: `mainwindow.py`, `controllers/base_tab_controller.py`, `controllers/recfid_controller.py`, `controllers/dq_controller.py`, `controllers/dq_temp_controller.py`, `controllers/dqmq_controller.py`, `controllers/general_se_dq_controller.py`, `controllers/gs_controller.py`, `controllers/se_controller.py`, and `controllers/t1t2_controller.py`.
- Kept existing logging behavior for developer details and avoided spamming the footer during tight loops (messages are only posted at user-visible action boundaries). 

### Testing
- Compiled the modified modules with `python3 -m compileall main.py mainwindow.py controllers utils dialogs calculations` which succeeded without syntax errors. 
- Searched for and validated consolidated usage with `rg` to ensure controllers call the shared API (found `show_status` / `_status` usages across the modified files). 
- Performed `git diff --check` and created a commit for the change set. 
- Attempted a headless UI instantiation to smoke-test the MainWindow, but instantiation was blocked in this environment because `PySide6` is not installed, so interactive runtime verification was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00deaef9e88327b62cd441082cff5c)