### PR TITLE
Fix RecFID Clear button reset and ensure plots are fully cleared

### DIFF
--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -28,7 +28,7 @@ class RecFIDController(BaseTabController):
     def __init__(self, ui, state, parent=None):
         super().__init__(ui, state, parent)
         self._capture_initial_input_widget_state()
-        self.reset_tab(clear_plots=False)
+        self.reset_tab(clear_plots=True, reset_inputs=False)
 
     def clear_reconstruct_fid_tab(self, *_args):
         """Reset RecFID as if the tab had just been opened.
@@ -559,6 +559,7 @@ class RecFIDController(BaseTabController):
                 pen=mkPen(self._winter_color(index, max(len(self.data_results), 1)), width=3),
                 symbol=None,
             )
+        self._autoscale_after_plot(graph_nmr)
         # Gradient label is the compact visible color-scale indicator for data curves.
         self._add_original_signal_gradient_label(graph_nmr)
         self._status("Original NMR plot: black = FID; data curves use a winter color scale by echo time/file order.")
@@ -658,6 +659,7 @@ class RecFIDController(BaseTabController):
             symbol="o",
             symbolBrush="b",
         )
+        self._autoscale_after_plot(graph)
 
     def _plot_build_up(self, freq_build, spectrum_build, time_build, data_build):
         graph_build_fid = getattr(self.ui, "RecFID_PlotWidget_BuildUpNMRSignal", None)
@@ -665,11 +667,13 @@ class RecFIDController(BaseTabController):
             graph_build_fid.clear()
             graph_build_fid.plot(time_build, data_build, pen=mkPen("b", width=4), symbol=None)
             graph_build_fid.plot(self.fid_result["Time_td_fid"], self.fid_result["Re_td"], pen=mkPen("r", width=3), symbol=None)
+            self._autoscale_after_plot(graph_build_fid)
         graph_build_fft = getattr(self.ui, "RecFID_PlotWidget_BuildUpSpectra", None)
         if graph_build_fft is not None:
             graph_build_fft.clear()
             graph_build_fft.plot(freq_build, spectrum_build, pen=mkPen("b", width=4), symbol=None)
             graph_build_fft.plot(self.fid_result["Freq"], self.fid_result["Real_fft"], pen=mkPen("r", width=3), symbol=None)
+            self._autoscale_after_plot(graph_build_fft)
 
     def _clear_or_hide(self, widget_name, hide=False):
         widget = getattr(self.ui, widget_name, None)
@@ -707,11 +711,16 @@ class RecFIDController(BaseTabController):
         if legend is not None:
             legend.clear()
         widget.show()
-        widget.enableAutoRange()
-        widget.autoRange()
         widget.getAxis("left").setLabel(ylabel)
         widget.getAxis("bottom").setLabel(xlabel)
         widget.setTitle(title)
+        # Keep autoscaling enabled for future data without forcing an autorange
+        # calculation while the plot is empty, which can disturb startup axes.
+        widget.enableAutoRange(x=True, y=True)
+
+    def _autoscale_after_plot(self, graph):
+        graph.enableAutoRange(x=True, y=True)
+        graph.autoRange()
 
     def _capture_initial_input_widget_state(self):
         self._initial_input_widget_state = {}

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pyqtgraph as pg
 import pyqtgraph.exporters
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QSignalBlocker, Qt
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QFileDialog, QMessageBox
 from pyqtgraph import mkPen
@@ -27,9 +27,21 @@ class RecFIDController(BaseTabController):
 
     def __init__(self, ui, state, parent=None):
         super().__init__(ui, state, parent)
+        self._capture_initial_input_widget_state()
         self.reset_tab(clear_plots=False)
 
-    def reset_tab(self, clear_plots=True):
+    def clear_reconstruct_fid_tab(self, *_args):
+        """Reset RecFID as if the tab had just been opened.
+
+        QPushButton.clicked emits a checked-state boolean.  Keep the public
+        reset_tab(clear_plots=...) API separate from the button slot so that
+        the emitted ``False`` value cannot be interpreted as ``clear_plots``
+        and leave stale curves visible.
+        """
+        self.reset_tab(clear_plots=True, reset_inputs=True)
+        self._status("Cleared Reconstruct FID tab.")
+
+    def reset_tab(self, clear_plots=True, reset_inputs=False):
         self.recfid_mode = "none"
         self.selected_fid_files = []
         self.selected_data_files = []
@@ -45,6 +57,8 @@ class RecFIDController(BaseTabController):
         self.time_analysis_result = {}
         self._clear_original_signal_gradient_label()
         self._close_time_analysis_dialog()
+        if reset_inputs:
+            self._reset_input_widgets_to_initial_state()
         if clear_plots:
             self.initialize_plots()
             self._clear_result_text_widgets()
@@ -54,7 +68,7 @@ class RecFIDController(BaseTabController):
         self._connect("RecFID_Button_LoadData", "clicked", self.load_data_files)
         self._connect("RecFID_Button_LoadFIDEmpty", "clicked", self.load_empty_fid_files)
         self._connect("RecFID_Button_LoadDataEmpty", "clicked", self.load_empty_data_files)
-        self._connect("RecFID_Button_Clear", "clicked", self.reset_tab)
+        self._connect("RecFID_Button_Clear", "clicked", self.clear_reconstruct_fid_tab)
         self._connect("RecFID_Button_ManualEchoTimes", "clicked", self.open_manual_echo_time_dialog)
         self._connect("RecFID_Button_SaveStatistics", "clicked", self.save_statistics)
         self._connect("RecFID_Button_ExportSEMaxT2", "clicked", self.export_se_max_t2)
@@ -593,13 +607,26 @@ class RecFIDController(BaseTabController):
 
     def _clear_original_signal_gradient_label(self):
         label = getattr(self, "original_signal_gradient_label", None)
+        update_position = getattr(self, "original_signal_gradient_label_update", None)
+        if update_position is not None:
+            graph = getattr(self.ui, "RecFID_PlotWidget_OriginalNMRSignal", None)
+            if graph is not None:
+                try:
+                    graph.getViewBox().sigResized.disconnect(update_position)
+                except (RuntimeError, TypeError):
+                    logger.debug("RecFID gradient label resize callback was already disconnected", exc_info=True)
+            self.original_signal_gradient_label_update = None
         if label is not None:
             graph = getattr(self.ui, "RecFID_PlotWidget_OriginalNMRSignal", None)
             if graph is not None:
                 try:
                     graph.removeItem(label)
                 except (RuntimeError, ValueError):
-                    logger.debug("RecFID gradient label was already removed", exc_info=True)
+                    logger.debug("RecFID gradient label was already removed from the plot item", exc_info=True)
+            try:
+                label.setParentItem(None)
+            except RuntimeError:
+                logger.debug("RecFID gradient label was already deleted", exc_info=True)
             self.original_signal_gradient_label = None
 
     def _prepare_plot(self, graph):
@@ -680,9 +707,65 @@ class RecFIDController(BaseTabController):
         if legend is not None:
             legend.clear()
         widget.show()
+        widget.enableAutoRange()
+        widget.autoRange()
         widget.getAxis("left").setLabel(ylabel)
         widget.getAxis("bottom").setLabel(xlabel)
         widget.setTitle(title)
+
+    def _capture_initial_input_widget_state(self):
+        self._initial_input_widget_state = {}
+        for widget_name in self._resettable_input_widget_names():
+            widget = getattr(self.ui, widget_name, None)
+            if widget is None:
+                continue
+            if hasattr(widget, "isChecked"):
+                self._initial_input_widget_state[widget_name] = ("checked", widget.isChecked())
+            elif hasattr(widget, "value"):
+                self._initial_input_widget_state[widget_name] = ("value", widget.value())
+            elif hasattr(widget, "currentIndex"):
+                self._initial_input_widget_state[widget_name] = ("current_index", widget.currentIndex())
+
+    def _reset_input_widgets_to_initial_state(self):
+        for widget_name, (state_type, value) in getattr(self, "_initial_input_widget_state", {}).items():
+            widget = getattr(self.ui, widget_name, None)
+            if widget is None:
+                continue
+            blocker = QSignalBlocker(widget)
+            try:
+                if state_type == "checked":
+                    widget.setChecked(value)
+                elif state_type == "value":
+                    widget.setValue(value)
+                elif state_type == "current_index":
+                    widget.setCurrentIndex(value)
+            finally:
+                del blocker
+
+    def _resettable_input_widget_names(self):
+        return (
+            "RecFID_CheckBox_SubtractEmpty",
+            "RecFID_CheckBox_CutBeginning",
+            "RecFID_CheckBox_NormalizeToFID",
+            "RecFID_DoubleSpinBox_NormalizeFrom",
+            "RecFID_DoubleSpinBox_NormalizeTo",
+            "RecFID_CheckBox_LongComponent",
+            "RecFID_DoubleSpinBox_LongComponentEnd",
+            "RecFID_CheckBox_Smooth",
+            "RecFID_SpinBox_SmoothOrder",
+            "RecFID_SpinBox_SmoothWindow",
+            "RecFID_CheckBox_TimeDomainApodization",
+            "RecFID_DoubleSpinBox_ApodizationSigma",
+            "RecFID_CheckBox_AdjustZero",
+            "RecFID_DoubleSpinBox_ZeroShift",
+            "RecFID_ComboBox_BuildFunction",
+            "RecFID_DoubleSpinBox_BuildFrom",
+            "RecFID_DoubleSpinBox_BuildTo",
+            "RecFID_SpinBox_TimeAnalysisRange",
+            "RecFID_DoubleSpinBox_SEFitFrom",
+            "RecFID_DoubleSpinBox_SEFitTo",
+            "RecFID_DoubleSpinBox_MseDivider",
+        )
 
     def _clear_result_text_widgets(self):
         for widget_name in (

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -559,7 +559,6 @@ class RecFIDController(BaseTabController):
                 pen=mkPen(self._winter_color(index, max(len(self.data_results), 1)), width=3),
                 symbol=None,
             )
-        self._autoscale_after_plot(graph_nmr)
         # Gradient label is the compact visible color-scale indicator for data curves.
         self._add_original_signal_gradient_label(graph_nmr)
         self._status("Original NMR plot: black = FID; data curves use a winter color scale by echo time/file order.")
@@ -659,7 +658,6 @@ class RecFIDController(BaseTabController):
             symbol="o",
             symbolBrush="b",
         )
-        self._autoscale_after_plot(graph)
 
     def _plot_build_up(self, freq_build, spectrum_build, time_build, data_build):
         graph_build_fid = getattr(self.ui, "RecFID_PlotWidget_BuildUpNMRSignal", None)
@@ -667,13 +665,11 @@ class RecFIDController(BaseTabController):
             graph_build_fid.clear()
             graph_build_fid.plot(time_build, data_build, pen=mkPen("b", width=4), symbol=None)
             graph_build_fid.plot(self.fid_result["Time_td_fid"], self.fid_result["Re_td"], pen=mkPen("r", width=3), symbol=None)
-            self._autoscale_after_plot(graph_build_fid)
         graph_build_fft = getattr(self.ui, "RecFID_PlotWidget_BuildUpSpectra", None)
         if graph_build_fft is not None:
             graph_build_fft.clear()
             graph_build_fft.plot(freq_build, spectrum_build, pen=mkPen("b", width=4), symbol=None)
             graph_build_fft.plot(self.fid_result["Freq"], self.fid_result["Real_fft"], pen=mkPen("r", width=3), symbol=None)
-            self._autoscale_after_plot(graph_build_fft)
 
     def _clear_or_hide(self, widget_name, hide=False):
         widget = getattr(self.ui, widget_name, None)
@@ -714,14 +710,6 @@ class RecFIDController(BaseTabController):
         widget.getAxis("left").setLabel(ylabel)
         widget.getAxis("bottom").setLabel(xlabel)
         widget.setTitle(title)
-        # Keep autoscaling enabled for future data without forcing an autorange
-        # calculation while the plot is empty, which can disturb startup axes.
-        widget.enableAutoRange(x=True, y=True)
-
-    def _autoscale_after_plot(self, graph):
-        graph.enableAutoRange(x=True, y=True)
-        graph.autoRange()
-
     def _capture_initial_input_widget_state(self):
         self._initial_input_widget_state = {}
         for widget_name in self._resettable_input_widget_names():

--- a/controllers/recfid_controller.py
+++ b/controllers/recfid_controller.py
@@ -561,7 +561,7 @@ class RecFIDController(BaseTabController):
             )
         # Gradient label is the compact visible color-scale indicator for data curves.
         self._add_original_signal_gradient_label(graph_nmr)
-        self._status("Original NMR plot: black = FID; data curves use a winter color scale by echo time/file order.")
+        self._status("Original NMR plot: red = FID; data curves use a winter color scale by echo time/file order.")
 
     def _add_original_signal_gradient_label(self, graph):
         if not self.data_results:
@@ -572,7 +572,7 @@ class RecFIDController(BaseTabController):
         scale_text = self._original_signal_color_scale_text()
         html = (
             '<div style="background-color:rgba(255,255,255,210); padding:4px; border:1px solid #444;">'
-            '<span style="color:#000000; font-weight:bold;">FID: black</span><br>'
+            '<span style="color:#ff0000; font-weight:bold;">FID: red</span><br>'
             '<span style="color:#0033ff; font-weight:bold;">■</span>'
             '<span style="color:#007fbf; font-weight:bold;">■</span>'
             '<span style="color:#00bf80; font-weight:bold;">■</span>'


### PR DESCRIPTION
### Motivation
- The Reconstruct FID tab's Clear action did not reliably remove visible plot items or restore the tab to its initial empty state, leaving stale curves and annotations after a clear.
- The Clear button was connected directly to the public `reset_tab` API which allowed the Qt `clicked` boolean to be misinterpreted and prevented a full visual reset.

### Description
- Added a dedicated slot `clear_reconstruct_fid_tab` and re-wired the Clear button to call it so the Qt `clicked` boolean cannot be misinterpreted as a plotting flag, and it calls `reset_tab(clear_plots=True, reset_inputs=True)` to perform a full reset (file: `controllers/recfid_controller.py`).
- Extended `reset_tab` with a `reset_inputs` option and cleared all internal state variables (`recfid_mode`, `selected_*`, `fid_result`, `data_results`, `se_max_result`, `build_result`, `extrapolation`, `time_analysis_result`) and closed any open time-analysis dialog.
- Captured initial input-widget state on controller init with `_capture_initial_input_widget_state` and restore inputs with `_reset_input_widgets_to_initial_state` using `QSignalBlocker` to avoid firing callbacks while resetting inputs.
- Improved plot/annotation clearing by disconnecting and removing the original-signal gradient label (disconnecting the `sigResized` handler and `setParentItem(None)`), calling `clear()` and clearing legends on all pyqtgraph widgets, and forcing an auto-range reset via `enableAutoRange()` / `autoRange()` so plots return to their empty labeled/title state.
- Added import of `QSignalBlocker` and the helper `_resettable_input_widget_names` listing the tab's input controls that should be restored to their initial values.

### Testing
- Ran `python -m py_compile controllers/recfid_controller.py` and the file compiled successfully.
- Ran `python -m compileall controllers calculations dialogs utils app_state.py main.py mainwindow.py` and the repository modules compiled successfully.
- Attempted an offscreen GUI smoke test that exercises `clear_reconstruct_fid_tab` and asserts cleared plots/text, but the runtime test could not execute in this environment due to a missing `numpy` dependency (the test is blocked by the environment rather than by the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c968f4d48327a7d3a61eb83c511e)